### PR TITLE
Don't use symlink for log location

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -51,7 +51,8 @@ class SimulatorXcode6 {
   }
 
   getLogDir () {
-    return path.resolve(this.getDir(), 'Library', 'Logs');
+    let home = process.env.HOME;
+    return path.resolve(home, 'Library', 'Logs', 'CoreSimulator', this.udid);
   }
 
   /*


### PR DESCRIPTION
There was a race condition between getting the sim log directory (which is a symlink) and making it. We end up not having any logs.

Use the full path to the sim log directory.