### PR TITLE
Fix hasAccess usage

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import * as simctl from 'node-simctl';
 import log from './logger';
-import { fs, util } from 'appium-support';
+import { fs } from 'appium-support';
 import B from 'bluebird';
 import _ from 'lodash';
 import { utils as instrumentsUtil } from 'appium-instruments';
@@ -177,7 +177,7 @@ class SimulatorXcode6 {
       return path.resolve(this.getDir(), s);
     });
 
-    let existence = await asyncmap(files, async (f) => { return util.hasAccess(f); });
+    let existence = await asyncmap(files, async (f) => { return fs.hasAccess(f); });
 
     existence = await B.all(existence); // will throw an error if an fs.stat call fails
 


### PR DESCRIPTION
I trying to use appium@v1.5.0-beta6 with Safari, but it raises the error:
```
error: [MJSONWP] Encountered internal error running command: TypeError: _appiumSupport.util.hasAccess is not a function
    at SimulatorXcode7.callee$2$0$ (lib/simulator-xcode-6.js:180:70)
    at tryCatch (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at new Promise (/Volumes/Second/repos/appium/node_modules/core-js/library/modules/es6.promise.js:182:7)
    at AsyncIterator.enqueue (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at callee$2$0 (lib/simulator-xcode-6.js:180:51)
    at Array.map (native)
    at asyncmap$ (lib/asyncbox.js:70:26)
    at tryCatch (/Volumes/Second/repos/appium/node_modules/asyncbox/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Volumes/Second/repos/appium/node_modules/asyncbox/node_modules/babel-runtime/regenerator/runtime.js:294:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/Volumes/Second/repos/appium/node_modules/asyncbox/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/Volumes/Second/repos/appium/node_modules/asyncbox/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/Volumes/Second/repos/appium/node_modules/asyncbox/node_modules/babel-runtime/regenerator/runtime.js:167:17)
    at new Promise (/Volumes/Second/repos/appium/node_modules/asyncbox/node_modules/core-js/library/modules/es6.promise.js:182:7)
    at AsyncIterator.enqueue (/Volumes/Second/repos/appium/node_modules/asyncbox/node_modules/babel-runtime/regenerator/runtime.js:166:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/Volumes/Second/repos/appium/node_modules/asyncbox/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/Volumes/Second/repos/appium/node_modules/asyncbox/node_modules/babel-runtime/regenerator/runtime.js:192:12)
    at asyncmap (lib/asyncbox.js:74:16)
    at SimulatorXcode7.isFresh$ (lib/simulator-xcode-6.js:180:27)
    at tryCatch (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/Volumes/Second/repos/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
```

This patch should fix it.