### PR TITLE
Add methods for getting device name string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language:
+  - objective-c
+
+before_install:
+
+install:
+  - rm -rf ~/.nvm
+  - git clone https://github.com/creationix/nvm.git ~/.nvm
+  - source ~/.nvm/nvm.sh
+  - nvm install 0.12
+  - node --version
+  - npm install
+  - npm install -g gulp
+
+script:
+  - gulp once
+
+after_success:
+    - gulp coveralls

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // transpile:main
 
-import { getSimulator } from './lib/simulator';
+import { getSimulator, getDeviceString } from './lib/simulator';
 import { killAllSimulators, endAllSimulatorDaemons } from './lib/utils';
 
-export { getSimulator, killAllSimulators, endAllSimulatorDaemons };
+export { getSimulator, getDeviceString, killAllSimulators, endAllSimulatorDaemons };

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -7,17 +7,13 @@ import B from 'bluebird';
 import _ from 'lodash';
 import { utils as instrumentsUtil } from 'appium-instruments';
 import { killAllSimulators, endAllSimulatorDaemons } from './utils.js';
-import _glob from 'glob';
-import { read } from './settings';
 import { asyncmap, waitForCondition, retryInterval } from 'asyncbox';
 import * as settings from './settings';
 import { exec } from 'teen_process';
+import  xcode from 'appium-xcode';
 
-
-const glob = B.promisify(_glob);
 
 // TODO add start with polling, fix launch and kill.
-
 
 class SimulatorXcode6 {
   constructor (udid, xcodeVersion) {
@@ -34,8 +30,6 @@ class SimulatorXcode6 {
 
     this.appDataBundlePaths = null;
   }
-
-  //TODO default constructor with no args should create a sim with some defaults
 
   async getPlatformVersion () {
     if (!this._platformVersion) {
@@ -98,7 +92,7 @@ class SimulatorXcode6 {
       applicationList = path.resolve(this.getDir(), 'Applications');
       pathBundlePair = async (dir) => {
         dir = path.resolve(applicationList, dir);
-        let appFiles = await glob(`${dir}/*.app`);
+        let appFiles = await fs.glob(`${dir}/*.app`);
         let bundleId = appFiles[0].match(/.*\/(.*)\.app/)[1];
         return {path: dir, bundleId};
       };
@@ -107,7 +101,7 @@ class SimulatorXcode6 {
       // given a directory, find the plist file and pull the bundle id from it
       let readBundleId = async (dir) => {
         let plist = path.resolve(dir, '.com.apple.mobile_container_manager.metadata.plist');
-        let metadata = await read(plist);
+        let metadata = await settings.read(plist);
         return metadata.MCMMetadataIdentifier;
       };
       // given a directory, return the path and bundle id associated with it
@@ -261,27 +255,32 @@ class SimulatorXcode6 {
     // Looks for launchd daemons corresponding to the sim udid and tries to stop them cleanly
     // This prevents xcrun simctl erase hangs.
     log.debug(`Killing any simulator daemons for ${this.udid}`);
+
+    let launchctlCmd = `launchctl list | grep ${this.udid} | cut -f 3 | xargs -n 1 launchctl`;
     try {
-      let stopCmd = `launchctl list | grep ${this.udid} | cut -f 3 | xargs -n 1 launchctl stop`;
+      let stopCmd = `${launchctlCmd} stop`;
       await exec('bash', ['-c', stopCmd]);
     } catch (err) {
-      log.warn('Could not stop simulator daemons, carrying on anyway!');
+      log.warn(`Could not stop simulator daemons: ${err.message}`);
+      log.debug('Carrying on anyway!');
     }
     try {
-      let removeCmd = `launchctl list | grep ${this.udid} | cut -f 3 | xargs -n 1 launchctl remove`;
+      let removeCmd = `${launchctlCmd} remove`;
       await exec('bash', ['-c', removeCmd]);
     } catch (err) {
-      log.warn('Could not remove simulator daemons, carrying on anyway!');
+      log.warn(`Could not remove simulator daemons: ${err.message}`);
+      log.debug('Carrying on anyway!');
     }
     try {
       // Waits 10 sec for the simulator launchd services to stop.
       await waitForCondition(async () => {
         let {stdout} = await exec('bash', ['-c',
           `ps -e  | grep ${this.udid} | grep launchd_sim | grep -v bash | grep -v grep | awk {'print$1'}`]);
-         return stdout.trim().length === 0;
+        return stdout.trim().length === 0;
       }, {waitMs: 10000, intervalMs: 500});
     } catch (err) {
-      log.warn(`Could not end simulator daemon for ${this.udid}, carrying on!`);
+      log.warn(`Could not end simulator daemon for ${this.udid}: ${err.message}`);
+      log.debug('Carrying on anyway!');
     }
   }
 
@@ -369,6 +368,84 @@ class SimulatorXcode6 {
     }
 
     await B.all(deletePromises);
+  }
+
+  static async _getDeviceStringPlatformVersion (platformVersion) {
+    let reqVersion = platformVersion;
+    if (!reqVersion) {
+      reqVersion = await xcode.getMaxIOSSDK();
+      // this will be a number, and possibly an integer (e.g., if max iOS SDK is 9)
+      // so turn it into a string and add a .0 if necessary
+      reqVersion = (reqVersion % 1) ? String(reqVersion) : `${reqVersion}.0`;
+    }
+    return reqVersion;
+  }
+
+  // change the format in subclasses, as necessary
+  static async _getDeviceStringVersionString (platformVersion) {
+    let reqVersion = await this._getDeviceStringPlatformVersion(platformVersion);
+
+    return `(${reqVersion} Simulator)`;
+  }
+
+  // change the format in subclasses, as necessary
+  static _getDeviceStringConfigFix () {
+    // some devices need to be updated
+    return {
+      'iPad Simulator (7.1 Simulator)': 'iPad 2 (7.1 Simulator)',
+      'iPad Simulator (8.0 Simulator)': 'iPad 2 (8.0 Simulator)',
+      'iPad Simulator (8.1 Simulator)': 'iPad 2 (8.1 Simulator)',
+      'iPad Simulator (8.2 Simulator)': 'iPad 2 (8.2 Simulator)',
+      'iPad Simulator (8.3 Simulator)': 'iPad 2 (8.3 Simulator)',
+      'iPad Simulator (8.4 Simulator)': 'iPad 2 (8.4 Simulator)',
+      'iPhone Simulator (7.1 Simulator)': 'iPhone 5s (7.1 Simulator)',
+      'iPhone Simulator (8.4 Simulator)': 'iPhone 6 (8.4 Simulator)',
+      'iPhone Simulator (8.3 Simulator)': 'iPhone 6 (8.3 Simulator)',
+      'iPhone Simulator (8.2 Simulator)': 'iPhone 6 (8.2 Simulator)',
+      'iPhone Simulator (8.1 Simulator)': 'iPhone 6 (8.1 Simulator)',
+      'iPhone Simulator (8.0 Simulator)': 'iPhone 6 (8.0 Simulator)'
+    };
+  }
+
+  static async getDeviceString (opts) {
+    opts = Object.assign({}, {
+      deviceName: null,
+      platformVersion: null,
+      forceIphone: false,
+      forceIpad: false
+    }, opts);
+    log.debug(`Getting device string: ${JSON.stringify(opts)}`);
+
+    // short circuit if we already have a device name
+    if ((opts.deviceName || '')[0] === '=') {
+      return opts.deviceName.substring(1);
+    }
+
+    let isiPhone = !!opts.forceIphone || !opts.forceIpad;
+
+    if (opts.deviceName) {
+      let device = opts.deviceName.toLowerCase();
+      if (device.indexOf('iphone') !== -1) {
+        isiPhone = true;
+      } else if (device.indexOf('ipad') !== -1) {
+        isiPhone = false;
+      }
+    }
+
+    let iosDeviceString = opts.deviceName || (isiPhone ? 'iPhone Simulator' : 'iPad Simulator');
+    iosDeviceString += ` ${await this._getDeviceStringVersionString(opts.platformVersion)}`;
+
+    let CONFIG_FIX = this._getDeviceStringConfigFix();
+
+    let configFix = CONFIG_FIX;
+    if (configFix[iosDeviceString]) {
+      iosDeviceString = configFix[iosDeviceString];
+      log.debug(`Fixing device. Changed from '${opts.deviceName}' `+
+                   `to '${iosDeviceString}'`);
+    }
+
+    log.debug(`Final device string is '${iosDeviceString}'`);
+    return iosDeviceString;
   }
 }
 

--- a/lib/simulator-xcode-7.js
+++ b/lib/simulator-xcode-7.js
@@ -1,9 +1,37 @@
 import SimulatorXcode6 from './simulator-xcode-6';
 
+
 class SimulatorXcode7 extends SimulatorXcode6 {
   // at the moment there is no difference
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
+  }
+
+  static async _getDeviceStringVersionString (platformVersion) {
+    let reqVersion = await this._getDeviceStringPlatformVersion(platformVersion);
+    return `(${reqVersion})`;
+  }
+
+  static _getDeviceStringConfigFix () {
+    return {
+      'iPad Simulator (8.1)': 'iPad 2 (8.1)',
+      'iPad Simulator (8.2)': 'iPad 2 (8.2)',
+      'iPad Simulator (8.3)': 'iPad 2 (8.3)',
+      'iPad Simulator (8.4)': 'iPad 2 (8.4)',
+      'iPad Simulator (9.0)': 'iPad 2 (9.0)',
+      'iPad Simulator (9.1)': 'iPad 2 (9.1)',
+      'iPhone Simulator (8.1)': 'iPhone 6 (8.1)',
+      'iPhone Simulator (8.2)': 'iPhone 6 (8.2)',
+      'iPhone Simulator (8.3)': 'iPhone 6 (8.3)',
+      'iPhone Simulator (8.4)': 'iPhone 6 (8.4)',
+      // Fixing ambiguous device name by adding '[' at the end so intruments
+      // correctly starts iPhone 6 [udid] and not the iPhone 6 (9.0) + Apple Watch
+      // for ios9.0 and above; see #5619
+      'iPhone Simulator (9.0)': 'iPhone 6 (9.0) [',
+      'iPhone Simulator (9.1)': 'iPhone 6 (9.1) [',
+      'iPhone 6 (9.0)': 'iPhone 6 (9.0) [',
+      'iPhone 6 (9.1)': 'iPhone 6 (9.1) ['
+    };
   }
 }
 

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -1,29 +1,46 @@
-
 import SimulatorXcode6 from './simulator-xcode-6';
 import SimulatorXcode7 from './simulator-xcode-7';
-import { getVersion } from 'appium-xcode';
+import xcode from 'appium-xcode';
 import log from './logger';
 
-async function getSimulator (udid, xcodeVersion) {
-  if (!xcodeVersion) {
-    xcodeVersion = await getVersion();
-  }
 
-  let majorVersion = parseInt(xcodeVersion[0], 10);
-  if (majorVersion < 6) {
+function handleUnsupportedXcode (xcodeVersion) {
+  if (xcodeVersion.major < 6) {
     throw new Error(`Tried to use an iOS simulator with xcode ` +
-                    `version ${xcodeVersion} but only Xcode version ` +
+                    `version ${xcodeVersion.versionString} but only Xcode version ` +
                     `6.0.0 and up are supported`);
-  } else if (majorVersion === 7) {
-    log.info(`Constructing iOS simulator for Xcode version ${xcodeVersion}`);
-    return new SimulatorXcode7(udid, xcodeVersion);
-  } else if (majorVersion === 6) {
-    log.info(`Constructing iOS simulator for Xcode version ${xcodeVersion}`);
-    return new SimulatorXcode6(udid, xcodeVersion);
-  } else {
+  } else if (xcodeVersion.major >= 8) {
     throw new Error(`Xcode version ${xcodeVersion} is ` +
                     `not yet supported`);
   }
 }
 
-export { getSimulator };
+async function getSimulator (udid) {
+  let xcodeVersion = await xcode.getVersion(true);
+
+  handleUnsupportedXcode(xcodeVersion);
+
+  if (xcodeVersion.major === 7) {
+    log.info(`Constructing iOS simulator for Xcode version ${xcodeVersion.versionString}`);
+    return new SimulatorXcode7(udid, xcodeVersion);
+  } else if (xcodeVersion.major === 6) {
+    log.info(`Constructing iOS simulator for Xcode version ${xcodeVersion.versionString}`);
+    return new SimulatorXcode6(udid, xcodeVersion);
+  }
+}
+
+async function getDeviceString (opts) {
+  let xcodeVersion = await xcode.getVersion(true);
+
+  handleUnsupportedXcode(xcodeVersion);
+
+  if (xcodeVersion.major === 7) {
+    log.info(`Retrieving device name string for Xcode version ${xcodeVersion.versionString}`);
+    return SimulatorXcode7.getDeviceString(opts);
+  } else if (xcodeVersion.major === 6) {
+    log.info(`Retrieving device name string for Xcode version ${xcodeVersion.versionString}`);
+    return SimulatorXcode6.getDeviceString(opts);
+  }
+}
+
+export { getSimulator, getDeviceString };

--- a/package.json
+++ b/package.json
@@ -23,20 +23,18 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-instruments": "3.0.0-beta14",
+    "appium-instruments": "^3.0.0",
     "appium-logger": "^2.0.0",
-    "appium-support": "^2.0.0",
+    "appium-support": "^2.0.5",
     "appium-xcode": "^3.0.1",
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.34",
-    "glob": "^5.0.14",
     "lodash": "^3.10.0",
     "ncp": "^2.0.0",
     "node-simctl": "^3.1.0",
-    "sinon": "^1.14.1",
-    "source-map-support": "^0.2.10",
-    "teen_process": "^1.2.2"
+    "source-map-support": "^0.3.2",
+    "teen_process": "^1.3.0"
   },
   "scripts": {
     "prepublish": "./node_modules/.bin/gulp prepublish",
@@ -46,9 +44,8 @@
   "devDependencies": {
     "appium-gulp-plugins": "^1.3.11",
     "chai": "^3.2.0",
-    "chai-as-promised": "^5.0.0",
+    "chai-as-promised": "^5.1.0",
     "gulp": "^3.8.11",
-    "sinon": "^1.15.4",
-    "yargs": "^3.9.0"
+    "sinon": "^1.15.4"
   }
 }

--- a/test/unit/simulator-specs.js
+++ b/test/unit/simulator-specs.js
@@ -1,6 +1,6 @@
 // transpile:mocha
 
-import { getSimulator } from '../..';
+import { getSimulator, getDeviceString } from '../..';
 import SimulatorXcode6 from '../../lib/simulator-xcode-6';
 import SimulatorXcode7 from '../../lib/simulator-xcode-7';
 import * as simctl from 'node-simctl';
@@ -11,80 +11,154 @@ import { devices } from '../assets/deviceList';
 import B from 'bluebird';
 import xcode from 'appium-xcode';
 
+
 let should = chai.should();
 chai.use(chaiAsPromised);
 
 describe('simulator', () => {
+  let xcodeMock;
 
-  let getVersionStub;
-
-  afterEach( () => {
-    getVersionStub.restore();
+  beforeEach(() => {
+    xcodeMock = sinon.mock(xcode);
+  });
+  afterEach(() => {
+    xcodeMock.restore();
   });
 
-  it('should create a simulator with default xcode version', async () => {
-    getVersionStub = sinon.stub(xcode, 'getVersion').returns('6.0.0');
+  describe('getSimulator', () => {
+    it('should create a simulator with default xcode version', async () => {
+      let xcodeVersion = {major: 6, versionString: '6.0.0'};
+      xcodeMock.expects('getVersion').returns(Promise.resolve(xcodeVersion));
 
-    let sim = await getSimulator('123');
-    sim.xcodeVersion.should.equal('6.0.0');
-    sim.should.be.an.instanceof(SimulatorXcode6);
-  });
-
-  it('should create an xcode 7 simulator with xcode version 7', async () => {
-    getVersionStub = sinon.stub(xcode, 'getVersion').returns('7.0.0');
-
-    let sim = await getSimulator('123');
-    sim.xcodeVersion.should.equal('7.0.0');
-    sim.should.be.an.instanceof(SimulatorXcode7);
-  });
-
-  it('should throw an error if xcode version less than 6', async () => {
-    getVersionStub = sinon.stub(xcode, 'getVersion').returns('5.4.0');
-
-    await getSimulator('123').should.eventually.be.rejectedWith('version');
-  });
-
-  it('should throw an error if xcode version above 7', async () => {
-    getVersionStub = sinon.stub(xcode, 'getVersion').returns('8.0.0');
-
-    await getSimulator('123').should.eventually.be.rejectedWith('not yet');
-  });
-
-  it('should list stats for sim', async () => {
-    getVersionStub = sinon.stub(xcode, 'getVersion').returns('6.0.0');
-    let getDevicesStub = sinon.stub(simctl, 'getDevices').returns(devices);
-
-    after(() => {
-      getDevicesStub.restore();
+      let sim = await getSimulator('123');
+      sim.xcodeVersion.should.equal(xcodeVersion);
+      sim.should.be.an.instanceof(SimulatorXcode6);
     });
 
-    let sims = [
-      getSimulator('F33783B2-9EE9-4A99-866E-E126ADBAD410'),
-      getSimulator('DFBC2970-9455-4FD9-BB62-9E4AE5AA6954'),
-      getSimulator('123')
-    ];
+    it('should create an xcode 7 simulator with xcode version 7', async () => {
+      let xcodeVersion = {major: 7, versionString: '7.0.0'};
+      xcodeMock.expects('getVersion').returns(Promise.resolve(xcodeVersion));
 
-    let stats = sims.map((simProm) => {
-      return simProm.then((sim) => {
-        return sim.stat();
+      let sim = await getSimulator('123');
+      sim.xcodeVersion.should.equal(xcodeVersion);
+      sim.should.be.an.instanceof(SimulatorXcode7);
+    });
+
+    it('should throw an error if xcode version less than 6', async () => {
+      let xcodeVersion = {major: 5, versionString: '5.4.0'};
+      xcodeMock.expects('getVersion').returns(Promise.resolve(xcodeVersion));
+
+      await getSimulator('123').should.eventually.be.rejectedWith('version');
+    });
+
+    it('should throw an error if xcode version above 7', async () => {
+      let xcodeVersion = {major: 8, versionString: '8.0.0'};
+      xcodeMock.expects('getVersion').returns(Promise.resolve(xcodeVersion));
+
+      await getSimulator('123').should.eventually.be.rejectedWith('not yet');
+    });
+
+    it('should list stats for sim', async () => {
+      let xcodeVersion = {major: 6, versionString: '6.0.0'};
+      xcodeMock.expects('getVersion').atLeast(1).returns(Promise.resolve(xcodeVersion));
+      let getDevicesStub = sinon.stub(simctl, 'getDevices').returns(devices);
+
+      let sims = [
+        getSimulator('F33783B2-9EE9-4A99-866E-E126ADBAD410'),
+        getSimulator('DFBC2970-9455-4FD9-BB62-9E4AE5AA6954'),
+        getSimulator('123')
+      ];
+
+      let stats = sims.map((simProm) => {
+        return simProm.then((sim) => {
+          return sim.stat();
+        });
+      });
+
+      stats = await B.all(stats);
+
+      stats[0].state.should.equal('Shutdown');
+      stats[1].state.should.equal('Booted');
+      should.not.exist(stats[2]);
+
+      getDevicesStub.restore();
+    });
+  });
+
+
+  describe('getDeviceString', () => {
+    describe('Xcode 6', () => {
+      let xcodeVersion = {major: 6, versionString: '6.0.0'};
+
+      beforeEach(() => {
+        xcodeMock.expects('getVersion').returns(Promise.resolve(xcodeVersion));
+      });
+
+      it('should get the correct device for iOS 8+', async () => {
+        xcodeMock.expects('getMaxIOSSDK').returns(Promise.resolve(8.4));
+        let device = await getDeviceString();
+        device.should.equal('iPhone 6 (8.4 Simulator)');
+      });
+      it('should get the correct device for iOS 8+ when platform version passed in', async () => {
+        let device = await getDeviceString({platformVersion: '8.1'});
+        device.should.equal('iPhone 6 (8.1 Simulator)');
+      });
+      it('should get the correct device for iOS 7+', async () => {
+        xcodeMock.expects('getMaxIOSSDK').returns(Promise.resolve(7.1));
+        let device = await getDeviceString();
+        device.should.equal('iPhone 5s (7.1 Simulator)');
+      });
+      it('should get the correct device for iOS 7+ when platform version passed in', async () => {
+        let device = await getDeviceString({platformVersion: '7.1'});
+        device.should.equal('iPhone 5s (7.1 Simulator)');
+      });
+      it('should pass through device name when passed with =', async () => {
+        xcodeMock.expects('getMaxIOSSDK').returns(Promise.resolve(8.4));
+        let device = await getDeviceString({deviceName: '=fancy device'});
+        device.should.equal('fancy device');
+      });
+      it('should add a device name when passed without =', async () => {
+        xcodeMock.expects('getMaxIOSSDK').returns(Promise.resolve(8.4));
+        let device = await getDeviceString({deviceName: 'fancy device'});
+        device.should.equal('fancy device (8.4 Simulator)');
       });
     });
 
-    stats = await B.all(stats);
+    describe('Xcode 7', () => {
+      let xcodeVersion = {major: 7, versionString: '7.0.0'};
 
-    stats[0].state.should.equal('Shutdown');
-    stats[1].state.should.equal('Booted');
-    should.not.exist(stats[2]);
-  });
+      beforeEach(() => {
+        xcodeMock.expects('getVersion').returns(Promise.resolve(xcodeVersion));
+      });
 
-  //it.skip('should fail to get a simulator with non-existent udid')
-
-  //it.skip('should create a new simulator')
-
-  //it.skip('should dectroy a simulator')
-  //TODO e2e tests. check that rootdir exists
-
-  it('should get a list of application data directories', async () => {
-
+      it('should get the correct device for iOS 8+', async () => {
+        xcodeMock.expects('getMaxIOSSDK').returns(Promise.resolve(8.4));
+        let device = await getDeviceString();
+        device.should.equal('iPhone 6 (8.4)');
+      });
+      it('should get the correct device for iOS 8+ when platform version passed in', async () => {
+        let device = await SimulatorXcode7.getDeviceString({platformVersion: '8.1'});
+        device.should.equal('iPhone 6 (8.1)');
+      });
+      it('should get the correct device for iOS 9+', async () => {
+        xcodeMock.expects('getMaxIOSSDK').returns(Promise.resolve(9));
+        let device = await getDeviceString();
+        device.should.equal('iPhone 6 (9.0) [');
+      });
+      it('should get the correct device for iOS 9+ when platform version passed in', async () => {
+        let device = await getDeviceString({platformVersion: '9.0'});
+        device.should.equal('iPhone 6 (9.0) [');
+      });
+      it('should pass through device name when passed with =', async () => {
+        xcodeMock.expects('getMaxIOSSDK').returns(Promise.resolve(9.0));
+        let device = await getDeviceString({deviceName: '=fancy device'});
+        device.should.equal('fancy device');
+      });
+      it('should add a device name when passed without =', async () => {
+        xcodeMock.expects('getMaxIOSSDK').returns(Promise.resolve(9.0));
+        let device = await getDeviceString({deviceName: 'fancy device'});
+        device.should.equal('fancy device (9.0)');
+      });
+    });
   });
 });

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -53,6 +53,7 @@ describe('util', () => {
       execStub.calledWith('pkill', ['-9', '-f', 'iOS Simulator']).should.be.true;
     });
     it('should ignore errors thrown by exec', async () => {
+      xcodeMock.expects('getVersion').withArgs(true).returns(Promise.resolve(XCODE_VERSION_7));
       execStub.throws();
       await killAllSimulators().should.not.be.rejected;
       execStub.threw().should.be.true;

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -27,14 +27,15 @@ const XCODE_VERSION_6 = {
 };
 
 describe('util', () => {
-  let execStub = sinon.stub(TeenProcess, 'exec');
+  let execStub;
   let xcodeMock;
 
   beforeEach(() => {
+    execStub = sinon.stub(TeenProcess, 'exec');
     xcodeMock = sinon.mock(xcode);
   });
   afterEach(() => {
-    execStub.reset();
+    execStub.restore();
     xcodeMock.restore();
   });
 


### PR DESCRIPTION
Rather than the iOS driver going through the rigamarole of getting the device name for a particular xcode/simulator combination, let this package do it.