### PR TITLE
killAllSimulators when calling sim.shutdown()

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -237,7 +237,6 @@ class SimulatorXcode6 {
 
     // and quit
     await this.shutdown();
-    await killAllSimulators();
   }
 
   async endSimulatorDaemon () {
@@ -281,6 +280,7 @@ class SimulatorXcode6 {
     }
     await this.endSimulatorDaemon();
     await endAllSimulatorDaemons();
+    await killAllSimulators();
   }
 
   async delete () {


### PR DESCRIPTION
@imurchie would this break anything you know of?

Prior to this change, the sim process would get "shutdown" but the Ui would remain up and be frozen. When in this state, the simulator can't be opened anymore.