### PR TITLE
BREAKING CHANGE: add simExists() function; getSimulator(udid) throws an error if udid does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ import { endAllSimulatorDaemons } from 'appium-ios-simulator';
 await endAllSimulatorDaemons();
 ```
 
+`async simExists(udid)`
+
+Returns true if a simulator with UDID exists on the host system. False otherwise.
+
+```js
+import { simExists } from 'appium-ios-simulator';
+
+await simExists('D94E4CD7-D412-4198-BCD4-26799672975E');
+```
+
 
 #### Simulator object
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ The `appium-ios-simulator` exports four utility functions: `getSimulator`, `getD
 
 `async getSimulator(udid)`
 
-This function takes the `udid` of a simulator, and returns a simulator object (see below) associated with that identifier.
+This is the main entry of this module.
+This function returns a simulator object (see below) associated with the udid passed in. If an iOS simulator with the given udid does not exist already on this machine, it will throw an error.
+
+If you want to create a new simulator, you can use the `createDevice()` method of [node-simctl](github.com/appium/node-simctl).
 
 ```js
 import { getSimulator } from 'appium-ios-simulator';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // transpile:main
 
 import { getSimulator, getDeviceString } from './lib/simulator';
-import { killAllSimulators, endAllSimulatorDaemons } from './lib/utils';
+import { killAllSimulators, endAllSimulatorDaemons, simExists } from './lib/utils';
 
-export { getSimulator, getDeviceString, killAllSimulators, endAllSimulatorDaemons };
+export { getSimulator, getDeviceString, killAllSimulators, endAllSimulatorDaemons, simExists };

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -6,7 +6,7 @@ import { fs, rimraf } from 'appium-support';
 import B from 'bluebird';
 import _ from 'lodash';
 import { utils as instrumentsUtil } from 'appium-instruments';
-import { killAllSimulators, endAllSimulatorDaemons, simExists } from './utils.js';
+import { killAllSimulators, endAllSimulatorDaemons } from './utils.js';
 import { asyncmap, waitForCondition, retryInterval } from 'asyncbox';
 import * as settings from './settings';
 import { exec } from 'teen_process';
@@ -16,10 +16,6 @@ import { tailUntil } from './tail-until.js';
 
 class SimulatorXcode6 {
   constructor (udid, xcodeVersion) {
-    if (!simExists(udid)) {
-      throw new Error(`No sim found with udid ${udid}`);
-    }
-
     this.udid = String(udid);
     this.xcodeVersion = xcodeVersion;
 

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -6,7 +6,7 @@ import { fs, rimraf } from 'appium-support';
 import B from 'bluebird';
 import _ from 'lodash';
 import { utils as instrumentsUtil } from 'appium-instruments';
-import { killAllSimulators, endAllSimulatorDaemons } from './utils.js';
+import { killAllSimulators, endAllSimulatorDaemons, simExists } from './utils.js';
 import { asyncmap, waitForCondition, retryInterval } from 'asyncbox';
 import * as settings from './settings';
 import { exec } from 'teen_process';
@@ -16,6 +16,10 @@ import { tailUntil } from './tail-until.js';
 
 class SimulatorXcode6 {
   constructor (udid, xcodeVersion) {
+    if (!simExists(udid)) {
+      throw new Error(`No sim found with udid ${udid}`);
+    }
+
     this.udid = String(udid);
     this.xcodeVersion = xcodeVersion;
 

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -1,5 +1,6 @@
 import SimulatorXcode6 from './simulator-xcode-6';
 import SimulatorXcode7 from './simulator-xcode-7';
+import { simExists } from './utils';
 import xcode from 'appium-xcode';
 import log from './logger';
 
@@ -17,6 +18,10 @@ function handleUnsupportedXcode (xcodeVersion) {
 
 async function getSimulator (udid) {
   let xcodeVersion = await xcode.getVersion(true);
+
+  if (!await simExists(udid)) {
+    throw new Error(`No sim found with udid ${udid}`);
+  }
 
   handleUnsupportedXcode(xcodeVersion);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,6 +55,7 @@ async function endAllSimulatorDaemons () {
 }
 
 async function simExists (udid) {
+  // see the README for github.com/appium/node-simctl for example output of getDevices()
   let devices = await getDevices();
 
   devices = _.pairs(devices).map((pair) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,9 @@
 import log from './logger';
+import _ from 'lodash';
 import { exec } from 'teen_process';
 import { waitForCondition } from 'asyncbox';
 import { getVersion } from 'appium-xcode';
+import { getDevices } from 'node-simctl';
 
 
 async function killAllSimulators () {
@@ -52,4 +54,17 @@ async function endAllSimulatorDaemons () {
   log.debug('Finishing ending all simulator daemons');
 }
 
-export { killAllSimulators, endAllSimulatorDaemons };
+async function simExists (udid) {
+  let devices = await getDevices();
+
+  devices = _.pairs(devices).map((pair) => {
+    return pair[1];
+  }).reduce((a, b) => {
+    return a.concat(b);
+  }, []);
+  return !!_.find(devices, (sim) => {
+    return sim.udid === udid;
+  });
+}
+
+export { killAllSimulators, endAllSimulatorDaemons, simExists };

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -8,6 +8,7 @@ import * as TeenProcess from 'teen_process';
 import xcode from 'appium-xcode';
 import * as nodeSimctl from 'node-simctl';
 import { killAllSimulators, endAllSimulatorDaemons, simExists } from '../..';
+import { devices } from '../assets/deviceList';
 
 
 chai.should();
@@ -37,6 +38,7 @@ describe('util', () => {
     execStub = sinon.stub(TeenProcess, 'exec');
     xcodeMock = sinon.mock(xcode);
     getDevicesStub = sinon.stub(nodeSimctl, 'getDevices');
+    getDevicesStub.returns(Promise.resolve(devices));
   });
   afterEach(() => {
     execStub.restore();
@@ -79,74 +81,33 @@ describe('util', () => {
   });
 
   describe('simExists', () => {
-    const devicesStub = {
-    '7.1': [
-     { name: 'iPhone 5',
-       udid: 'B236B73C-8EFA-4284-AC1F-2A45F3286E4C',
-       state: 'Shutdown' },
-     { name: 'iPhone 5s',
-       udid: '8E248C90-0F79-46AD-9CAA-8DF3B6E3FBA6',
-       state: 'Shutdown' },
-     { name: 'iPad Air',
-       udid: 'FA5C971D-4E05-4AA3-B48B-C9619C7453BE',
-       state: 'Shutdown' } ],
-    '8.1': [
-     { name: 'iPhone 5',
-       udid: 'B5048708-566E-45D5-9885-C878EF7D6D13',
-       state: 'Shutdown' },
-     { name: 'iPhone 5s',
-       udid: '2F7678F2-FD52-497F-9383-41D3BB401FBD',
-       state: 'Shutdown' },
-     { name: 'iPhone 6 Plus',
-       udid: '013D6994-B4E6-4548-AD77-C0D7C6C6D245',
-       state: 'Shutdown' } ],
-    '8.3': [
-     { name: 'iPhone 5',
-       udid: '813AAB6A-32C8-4859-A5CF-F3355C244F54',
-       state: 'Shutdown' },
-     { name: 'iPhone 5s',
-       udid: '9D3A405E-65D6-4743-85DA-E644DA9A8373',
-       state: 'Shutdown' },
-     { name: 'iPhone 6 Plus',
-       udid: 'D94E4CD7-D412-4198-BCD4-26799672975E',
-       state: 'Shutdown' },
-     { name: 'iPhone 6',
-       udid: '26EAADAE-1CD5-42F9-9A4C-50554CDF0910',
-       state: 'Shutdown' },
-     { name: 'iPad 2',
-       udid: 'C8E68217-82E6-42A8-8326-9824CA2E7C7C',
-       state: 'Shutdown' } ]
-  };
 
-  it('returns true if device is found', async () => {
-    getDevicesStub.returns(Promise.resolve(devicesStub));
-    let existence = [];
-     existence.push(simExists('D94E4CD7-D412-4198-BCD4-26799672975E'));
-     existence.push(simExists('C8E68217-82E6-42A8-8326-9824CA2E7C7C'));
-     existence.push(simExists('B5048708-566E-45D5-9885-C878EF7D6D13'));
-     existence.push(simExists('8E248C90-0F79-46AD-9CAA-8DF3B6E3FBA6'));
+    it('returns true if device is found', async () => {
+      let existence = [
+       simExists('C09B34E5-7DCB-442E-B79C-AB6BC0357417'),
+       simExists('FA5C971D-4E05-4AA3-B48B-C9619C7453BE'),
+       simExists('E46EFA59-E2B4-4FF9-B290-B61F3CFECC65'),
+       simExists('F33783B2-9EE9-4A99-866E-E126ADBAD410')
+     ];
 
-     let results = await B.all(existence);
+       let results = await B.all(existence);
 
-     for (let result of results) {
-       result.should.be.true;
-     }
-  });
+       for (let result of results) {
+         result.should.be.true;
+       }
+    });
 
-  it('returns false if device is not found', async () => {
-    getDevicesStub.returns(Promise.resolve(devicesStub));
-    let existence = [];
-     existence.push(simExists('A94E4CD7-D412-4198-BCD4-26799672975E'));
-     existence.push(simExists('asdf'));
-     existence.push(simExists(4));
+    it('returns false if device is not found', async () => {
+      let existence = [];
+       existence.push(simExists('A94E4CD7-D412-4198-BCD4-26799672975E'));
+       existence.push(simExists('asdf'));
+       existence.push(simExists(4));
 
-     let results = await B.all(existence);
+       let results = await B.all(existence);
 
-     for (let result of results) {
-       result.should.be.false;
-     }
-  });
-
-
+       for (let result of results) {
+         result.should.be.false;
+       }
+    });
   });
 });

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -3,9 +3,11 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
+import B from 'bluebird';
 import * as TeenProcess from 'teen_process';
 import xcode from 'appium-xcode';
-import { killAllSimulators, endAllSimulatorDaemons } from '../..';
+import * as nodeSimctl from 'node-simctl';
+import { killAllSimulators, endAllSimulatorDaemons, simExists } from '../..';
 
 
 chai.should();
@@ -29,14 +31,17 @@ const XCODE_VERSION_6 = {
 describe('util', () => {
   let execStub;
   let xcodeMock;
+  let getDevicesStub;
 
   beforeEach(() => {
     execStub = sinon.stub(TeenProcess, 'exec');
     xcodeMock = sinon.mock(xcode);
+    getDevicesStub = sinon.stub(nodeSimctl, 'getDevices');
   });
   afterEach(() => {
     execStub.restore();
     xcodeMock.restore();
+    nodeSimctl.getDevices.restore();
   });
 
   describe('killAllSimulators', () => {
@@ -71,5 +76,77 @@ describe('util', () => {
       execStub.callCount.should.equal(5);
       execStub.threw().should.be.true;
     });
+  });
+
+  describe('simExists', () => {
+    const devicesStub = {
+    '7.1': [
+     { name: 'iPhone 5',
+       udid: 'B236B73C-8EFA-4284-AC1F-2A45F3286E4C',
+       state: 'Shutdown' },
+     { name: 'iPhone 5s',
+       udid: '8E248C90-0F79-46AD-9CAA-8DF3B6E3FBA6',
+       state: 'Shutdown' },
+     { name: 'iPad Air',
+       udid: 'FA5C971D-4E05-4AA3-B48B-C9619C7453BE',
+       state: 'Shutdown' } ],
+    '8.1': [
+     { name: 'iPhone 5',
+       udid: 'B5048708-566E-45D5-9885-C878EF7D6D13',
+       state: 'Shutdown' },
+     { name: 'iPhone 5s',
+       udid: '2F7678F2-FD52-497F-9383-41D3BB401FBD',
+       state: 'Shutdown' },
+     { name: 'iPhone 6 Plus',
+       udid: '013D6994-B4E6-4548-AD77-C0D7C6C6D245',
+       state: 'Shutdown' } ],
+    '8.3': [
+     { name: 'iPhone 5',
+       udid: '813AAB6A-32C8-4859-A5CF-F3355C244F54',
+       state: 'Shutdown' },
+     { name: 'iPhone 5s',
+       udid: '9D3A405E-65D6-4743-85DA-E644DA9A8373',
+       state: 'Shutdown' },
+     { name: 'iPhone 6 Plus',
+       udid: 'D94E4CD7-D412-4198-BCD4-26799672975E',
+       state: 'Shutdown' },
+     { name: 'iPhone 6',
+       udid: '26EAADAE-1CD5-42F9-9A4C-50554CDF0910',
+       state: 'Shutdown' },
+     { name: 'iPad 2',
+       udid: 'C8E68217-82E6-42A8-8326-9824CA2E7C7C',
+       state: 'Shutdown' } ]
+  };
+
+  it('returns true if device is found', async () => {
+    getDevicesStub.returns(Promise.resolve(devicesStub));
+    let existence = [];
+     existence.push(simExists('D94E4CD7-D412-4198-BCD4-26799672975E'));
+     existence.push(simExists('C8E68217-82E6-42A8-8326-9824CA2E7C7C'));
+     existence.push(simExists('B5048708-566E-45D5-9885-C878EF7D6D13'));
+     existence.push(simExists('8E248C90-0F79-46AD-9CAA-8DF3B6E3FBA6'));
+
+     let results = await B.all(existence);
+
+     for (let result of results) {
+       result.should.be.true;
+     }
+  });
+
+  it('returns false if device is not found', async () => {
+    getDevicesStub.returns(Promise.resolve(devicesStub));
+    let existence = [];
+     existence.push(simExists('A94E4CD7-D412-4198-BCD4-26799672975E'));
+     existence.push(simExists('asdf'));
+     existence.push(simExists(4));
+
+     let results = await B.all(existence);
+
+     for (let result of results) {
+       result.should.be.false;
+     }
+  });
+
+
   });
 });


### PR DESCRIPTION
breaking change. Before, we would just create a Simulator object with a completely made up udid, if thats what you asked for.

I don't think that's useful though. When will we be creating simulator objects that aren't tied to actual simulators.

You can still create a fake one if calling the constructor directly. But the `getSimulator` method now checks that the sim exists. Makes sense to me. @imurchie ?