### PR TITLE
Use "openUrl" to start safari in launchAndQuit() instead of using Instruments

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ Delete the Safari application.
 
 Clean up the directories for Safari.
 
+`async tailLogsUntil (bootedIndicator, timeoutMs)`
+
+Tails the iOS system log of this simulator.
+Returns a promise that is resolved when the string `bootedIndicator` is output in the log.
+Times out after `timeoutMs` milliseconds.
+
 `static async getDeviceString (opts)`
 
 Static (class) method to get the particular device name string for Instruments to identify the device. Use exported `getDeviceString` method instead of this.

--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ Starts the simulator without any Instruments involvement, or application running
 
 `async openUrl (url)`
 
-*Xcode version 7 and up only*
-
 Opens the input url with safari.
 
 `async clean ()`

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -460,8 +460,12 @@ class SimulatorXcode6 {
     return [newAppPath, appPath];
   }
 
-  async openUrl () {
-    throw new Error('Command "openUrl" not supported on Xcode version 6');
+  async openUrl (url) {
+    if (await this.isRunning()) {
+      return await simctl.openUrl(this.udid, url);
+    } else {
+      throw new Error('Tried to open a url, but the Simulator is not Booted');
+    }
   }
 
   static async _getDeviceStringPlatformVersion (platformVersion) {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -193,10 +193,8 @@ class SimulatorXcode6 {
       case '8.1':
       case '8.2':
       case '8.3':
-        indicator = 'profiled: Service starting...';
-        break;
       case '8.4':
-        indicator = 'MC: Finished cleaning up app configuration';
+        indicator = 'profiled: Service starting...';
         break;
       case '9.0':
       case '9.1':

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -5,7 +5,6 @@ import log from './logger';
 import { fs } from 'appium-support';
 import B from 'bluebird';
 import _ from 'lodash';
-import { utils as instrumentsUtil } from 'appium-instruments';
 import { killAllSimulators, endAllSimulatorDaemons, safeRimRaf } from './utils.js';
 import { asyncmap, waitForCondition, retryInterval } from 'asyncbox';
 import * as settings from './settings';
@@ -194,7 +193,7 @@ class SimulatorXcode6 {
       case '8.1':
       case '8.2':
       case '8.3':
-        indicator = 'Migration complete (if performed)';
+        indicator = 'profiled: Service starting...';
         break;
       case '8.4':
         indicator = 'MC: Finished cleaning up app configuration';
@@ -306,10 +305,10 @@ class SimulatorXcode6 {
     log.debug('Attempting to launch and quit the simulator, to create directory structure');
     log.debug(`Will launch with Safari? ${safari}`);
 
+    await this.run();
+
     if (safari) {
-      await instrumentsUtil.quickLaunch(this.udid, 'com.apple.mobilesafari');
-    } else {
-      await this.run();
+      await this.openUrl('http://www.appium.io');
     }
 
     // wait for the system to create the files we will manipulate
@@ -326,7 +325,7 @@ class SimulatorXcode6 {
     });
 
     // and quit
-    await this.shutdown();
+    //await this.shutdown();
   }
 
   async endSimulatorDaemon () {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -225,23 +225,13 @@ class SimulatorXcode6 {
     // it claims to be booted way before finishing loading
     // let's tail the simulator system log until we see a magic line (this.bootedIndicator)
     let bootedIndicator = await this.getBootedIndicatorString();
-    let simLog = path.resolve(this.getLogDir(), 'system.log');
-    // we need to make sure log file exists before we can tail it
-    await retryInterval(120, 200, async () => {
-      if (!await fs.exists(simLog)) {
-        throw new Error('not ready yet');
-      }
-    });
-
-    try {
-      await tailUntil(simLog, bootedIndicator, STARTUP_TIMEOUT);
-    } catch (err) {
-      log.debug('Simulator startup timed out. Continuing anyway.');
-    }
+    await this.tailLogsUntil(bootedIndicator, STARTUP_TIMEOUT);
 
     // so sorry, but we should wait another two seconds, just to make sure we've really started
     // we can't look for another magic log line, because they seem to be app-dependent (not system dependent)
+    log.debug(`Waiting and extra ${EXTRA_STARTUP_TIME}ms for the simulator to really finish booting`);
     await B.delay(EXTRA_STARTUP_TIME);
+    log.debug('Done waiting extra time for simulator');
     log.info(`Simulator booted in ${Date.now() - startTime}ms`);
   }
 
@@ -325,7 +315,7 @@ class SimulatorXcode6 {
     });
 
     // and quit
-    //await this.shutdown();
+    await this.shutdown();
   }
 
   async endSimulatorDaemon () {
@@ -460,10 +450,38 @@ class SimulatorXcode6 {
   }
 
   async openUrl (url) {
+    const SAFARI_BOOTED_INDICATOR = 'MobileSafari[';
+    const SAFARI_STARTUP_TIMEOUT = 15 * 1000;
+    const EXTRA_STARTUP_TIME = 3 * 1000;
+
     if (await this.isRunning()) {
-      return await simctl.openUrl(this.udid, url);
+      await simctl.openUrl(this.udid, url);
+      await this.tailLogsUntil(SAFARI_BOOTED_INDICATOR, SAFARI_STARTUP_TIMEOUT);
+      // So sorry, but the logs have nothing else for Safari starting.. just delay a little bit
+      log.debug(`Safari started, waiting ${EXTRA_STARTUP_TIME}ms for it to fully start`);
+      await B.delay(EXTRA_STARTUP_TIME);
+      log.debug('Done waiting for Safari');
+      return;
     } else {
       throw new Error('Tried to open a url, but the Simulator is not Booted');
+    }
+  }
+
+  // returns a promise that resolves when the ios simulator logs output a line matching `bootedIndicator`
+  // times out after timeoutMs
+  async tailLogsUntil (bootedIndicator, timeoutMs) {
+    let simLog = path.resolve(this.getLogDir(), 'system.log');
+    // we need to make sure log file exists before we can tail it
+    await retryInterval(120, 300, async () => {
+      if (!await fs.exists(simLog)) {
+        throw new Error('Could not find Simulator log');
+      }
+    });
+
+    try {
+      await tailUntil(simLog, bootedIndicator, timeoutMs);
+    } catch (err) {
+      log.debug('Simulator startup timed out. Continuing anyway.');
     }
   }
 

--- a/lib/simulator-xcode-7.js
+++ b/lib/simulator-xcode-7.js
@@ -1,5 +1,4 @@
 import SimulatorXcode6 from './simulator-xcode-6';
-import { openUrl } from 'node-simctl';
 
 class SimulatorXcode7 extends SimulatorXcode6 {
 
@@ -46,14 +45,6 @@ class SimulatorXcode7 extends SimulatorXcode6 {
       'iPhone 6s Plus (9.1)': 'iPhone 6s Plus (9.1) [',
       'iPhone 6s Plus (9.2)': 'iPhone 6s Plus (9.2) [',
     };
-  }
-
-  async openUrl (url) {
-    if (await this.isRunning()) {
-      return await openUrl(this.udid, url);
-    } else {
-      throw new Error('Tried to open a url, but the Simulator is not Booted');
-    }
   }
 }
 

--- a/lib/tail-until.js
+++ b/lib/tail-until.js
@@ -6,10 +6,10 @@ async function tailUntil (filePath, until, timeout = 5000) {
   let proc = new SubProcess('tail', ['-f', '-n', '0', filePath]);
 
   // // for debugging
-  // function consoleOut (...args) {
-  //   console.log(`>>> ${args}`);
-  // }
-  // proc.on('output', consoleOut);
+  function consoleOut (...args) {
+    console.log(`>>> ${args}`);
+  }
+  proc.on('output', consoleOut);
 
   let startDetector = (stdout) => {
     return stdout.indexOf(until) > -1;
@@ -26,7 +26,7 @@ async function tailUntil (filePath, until, timeout = 5000) {
     resolve();
   }).finally(() => {
     // no matter what, stop the tail process
-    proc.stop();
+//    proc.stop();
   });
 }
 

--- a/lib/tail-until.js
+++ b/lib/tail-until.js
@@ -5,11 +5,11 @@ import B from 'bluebird';
 async function tailUntil (filePath, until, timeout = 5000) {
   let proc = new SubProcess('tail', ['-f', '-n', '0', filePath]);
 
-  // // for debugging
-  function consoleOut (...args) {
-    console.log(`>>> ${args}`);
-  }
-  proc.on('output', consoleOut);
+  // for debugging
+  // function consoleOut (...args) {
+  //   console.log(`>>> ${args}`);
+  // }
+  // proc.on('output', consoleOut);
 
   let startDetector = (stdout) => {
     return stdout.indexOf(until) > -1;
@@ -26,7 +26,7 @@ async function tailUntil (filePath, until, timeout = 5000) {
     resolve();
   }).finally(() => {
     // no matter what, stop the tail process
-//    proc.stop();
+    proc.stop();
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-instruments": "^3.0.0",
     "appium-logger": "^2.0.0",
     "appium-support": "^2.0.7",
     "appium-xcode": "^3.0.1",

--- a/test/simulator-e2e-specs.js
+++ b/test/simulator-e2e-specs.js
@@ -50,6 +50,13 @@ function runTests (deviceType) {
       (await sim.stat()).state.should.equal('Shutdown');
     });
 
+    it('should launch and shutdown a sim, also starting safari', async function () {
+      let sim = await getSimulator(udid);
+      await sim.launchAndQuit(true);
+      (await sim.stat()).state.should.equal('Shutdown');
+    });
+
+
     it('should clean a sim', async function () {
       let sim = await getSimulator(udid);
       await sim.isFresh().should.eventually.equal(true);


### PR DESCRIPTION
This way is less hacky, and removes a dependency from the project.

I also improved the openUrl() function so that it respects async better. It used to return as soon as it was called, now it waits a little bit. (I try to tail the system logs, but unfortunately still have a hardcoded wait :( on top of that)

@imurchie for review