### PR TITLE
freshSim fix + plist tweak

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -65,7 +65,7 @@ async function update (pathToPlist, updates) {
 
   let currentSettings = await read(pathToPlist);
   let newSettings = _.merge(currentSettings, updates);
-  await plist.updatePlistFile(pathToPlist, newSettings, true);
+  await plist.updatePlistFile(pathToPlist, newSettings, true, false);
 
   return newSettings;
 }
@@ -82,7 +82,7 @@ async function readSettings (sim, plist) {
 
 async function read (pathToPlist) {
   log.debug(`Retrieving settings for ${pathToPlist}`);
-  return await plist.parsePlistFile(pathToPlist);
+  return await plist.parsePlistFile(pathToPlist, false);
 }
 
 async function updateLocationSettings (sim, bundleId, authorized) {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -162,6 +162,7 @@ class SimulatorXcode6 {
     ];
     let pv = await this.getPlatformVersion();
     if (pv !== '7.1') {
+      // iOS 7.1, 8.0, 8.1 and 9+ don't have a DeviceRegistry.state file
       if (pv !== '8.0' && pv !== '8.1' && pv[0] !== '9') {
         files.push('Library/DeviceRegistry.state');
       }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -162,7 +162,7 @@ class SimulatorXcode6 {
     ];
     let pv = await this.getPlatformVersion();
     if (pv !== '7.1') {
-      if (pv[0] !== '9') {
+      if (pv !== '8.0' && pv !== '8.1' && pv[0] !== '9') {
         files.push('Library/DeviceRegistry.state');
       }
       files.push('Library/Preferences/com.apple.Preferences.plist');


### PR DESCRIPTION
- Resolves issue where iOS 8 and iOS 8.1 get stuck in a loop waiting for a fresh simulator.
- Takes advantage of a laxer parsePlistFile method, returning a blank plist file instead of throwing.

@jlipps 
