### PR TITLE
fixed bundle path map async issue

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -111,14 +111,16 @@ class SimulatorXcode6 {
       };
     }
 
-    let bundlePathPairs = await fs.readdir(applicationList).map(pathBundlePair).then((pairs) => {
-      // reduce the list of path-bundle pairs to an object where bundleIds are mapped to paths
-      return pairs.reduce((bundleMap, bundlePath) => {
-        bundleMap[bundlePath.bundleId] = bundlePath.path;
-        return bundleMap;
-      }, {});
-    });
-    return bundlePathPairs;
+    let bundlePathDirs = await fs.readdir(applicationList);
+    let bundlePathPairs = await asyncmap(bundlePathDirs, async (dir) => { 
+      return await pathBundlePair(dir);
+    }, false);
+
+    // reduce the list of path-bundle pairs to an object where bundleIds are mapped to paths
+    return bundlePathPairs.reduce((bundleMap, bundlePath) => {
+      bundleMap[bundlePath.bundleId] = bundlePath.path;
+      return bundleMap;
+    }, {});
   }
 
   // returns state and specifics of this sim.


### PR DESCRIPTION
Please review @imurchie 

Async issue resolved:
![image](https://cloud.githubusercontent.com/assets/4726068/12273167/3e48a902-b919-11e5-97fe-072df842fc9a.png)

We could eventually collapse these logs into one or two lines. To do this we could use a global logging variable or pass through an additional parameter - but this would get messy with 3 libs involved.

Maybe something like:
```
log.debug('Updated Safari plist');
env.logging = 'none'
// process our plists
env.logging = 'info'
log.debug('Updated Safari plist');
```

Is something like this already in place?