### PR TITLE
Add 9.2 boot indicator

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -112,7 +112,7 @@ class SimulatorXcode6 {
     }
 
     let bundlePathDirs = await fs.readdir(applicationList);
-    let bundlePathPairs = await asyncmap(bundlePathDirs, async (dir) => { 
+    let bundlePathPairs = await asyncmap(bundlePathDirs, async (dir) => {
       return await pathBundlePair(dir);
     }, false);
 
@@ -190,7 +190,8 @@ class SimulatorXcode6 {
 
   async getBootedIndicatorString () {
     let indicator;
-    switch (await this.getPlatformVersion()) {
+    let platformVersion = await this.getPlatformVersion();
+    switch (platformVersion) {
       case '7.1':
       case '8.1':
       case '8.2':
@@ -200,9 +201,11 @@ class SimulatorXcode6 {
         break;
       case '9.0':
       case '9.1':
+      case '9.2':
         indicator = 'System app "com.apple.springboard" finished startup';
         break;
       default:
+        log.warn(`No boot indicator case for platform version '${platformVersion}'`);
         indicator = 'no boot indicator string available';
     }
     return indicator;


### PR DESCRIPTION
I got sick of waiting for the test to wait 60 seconds in order to timeout. Investigated and the indicator is the same.

@Jonahss review?