### PR TITLE
Remove logs from isFresh check

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -35,7 +35,6 @@ class SimulatorXcode6 {
     this.isFreshFiles = [
       'Library/ConfigurationProfiles',
       'Library/Cookies',
-      'Library/Logs',
       'Library/Preferences/.GlobalPreferences.plist',
       'Library/Preferences/com.apple.springboard.plist',
       'var/run/syslog.pid'

--- a/lib/simulator-xcode-7.3.js
+++ b/lib/simulator-xcode-7.3.js
@@ -9,7 +9,6 @@ class SimulatorXcode73 extends SimulatorXcode7 {
     this.isFreshFiles = [
       'Library/UserConfigurationProfiles',
       'Library/Cookies',
-      'Library/Logs',
       'Library/Preferences/.GlobalPreferences.plist',
       'Library/Preferences/com.apple.springboard.plist',
       'var/run/syslog.pid'


### PR DESCRIPTION
We don't need to have the logs folder present to consider the file not fresh.