### PR TITLE
Make sure locale is not updated if it is not necessary

### DIFF
--- a/lib/extensions/isolate-sim.js
+++ b/lib/extensions/isolate-sim.js
@@ -11,8 +11,8 @@ async function getAllUdids () {
   return _.chain(devices)
     .values()
     .flatten()
-    .pluck('udid')
-  .value();
+    .map('udid')
+    .value();
 }
 
 extensions.isolateSim = async function () {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -153,7 +153,7 @@ async function updateSafariUserSettings (sim, settingSet) {
   if (_.size(newUserSettings) > 0) {
     log.debug('Updating Safari user settings');
     let curUserSettings = await readSettings(sim, 'userSettings');
-    for (let [file, userSettingSet] of _.pairs(curUserSettings)) {
+    for (let [file, userSettingSet] of _.toPairs(curUserSettings)) {
       // the user settings plist has two buckets, one for
       // boolean settings (`restrictedBool`) and one for
       // other value settings (`restrictedValue`). In each, the value
@@ -161,7 +161,7 @@ async function updateSafariUserSettings (sim, settingSet) {
       if (!_.has(userSettingSet, 'restrictedBool')) {
         userSettingSet.restrictedBool = {};
       }
-      for (let [key, value] of _.pairs(newUserSettings)) {
+      for (let [key, value] of _.toPairs(newUserSettings)) {
         userSettingSet.restrictedBool[key] = {value};
       }
 
@@ -179,11 +179,14 @@ async function updateLocale (sim, language, locale, calendarFormat) {
   let data = await read(globalPrefs);
   let updates = {};
 
-  // if we are setting the language, add it to the list of languages
+  // if we are setting the language, add it to the beginning of the list of languages
   if (language) {
     log.debug(`New language: ${language}`);
     let supportedLangs = data.AppleLanguages || [];
-    updates.AppleLanguages = [language].concat(_.without(supportedLangs, language));
+    // if the language is first, we don't need to do anything
+    if (supportedLangs.indexOf(language) !== 0) {
+      updates.AppleLanguages = [language].concat(_.without(supportedLangs, language));
+    }
   }
   // if we are setting the locale or calendar format, set them as appropriate
   if (locale || calendarFormat) {
@@ -200,12 +203,21 @@ async function updateLocale (sim, language, locale, calendarFormat) {
     if (calendarFormat) {
       newLocaleAndCal = `${newLocaleAndCal}${calendarFormat}`;
     }
-    log.debug(`New locale: ${newLocaleAndCal}`);
-    updates.AppleLocale = newLocaleAndCal;
+    // only need to update if it has changed
+    if (newLocaleAndCal !== curLocaleAndCal) {
+      log.debug(`New locale: ${newLocaleAndCal}`);
+      updates.AppleLocale = newLocaleAndCal;
+    }
+  }
+
+  if (_.size(updates) === 0) {
+    log.debug('No locale updates necessary.');
+    return false;
   }
 
   log.debug('Writing new locale plist data');
   await update(globalPrefs, updates);
+  return true;
 }
 
 async function stub () {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -146,7 +146,7 @@ class SimulatorXcode6 {
     let normalizedDevices = [];
 
     // add sdk attribute to all entries, add to normalizedDevices
-    for (let [sdk, deviceArr] of _.pairs(devices)) {
+    for (let [sdk, deviceArr] of _.toPairs(devices)) {
       deviceArr = deviceArr.map((device) => {
         device.sdk = sdk;
         return device;
@@ -154,7 +154,7 @@ class SimulatorXcode6 {
       normalizedDevices = normalizedDevices.concat(deviceArr);
     }
 
-    return _.findWhere(normalizedDevices, {udid: this.udid});
+    return _.find(normalizedDevices, {udid: this.udid});
   }
 
   async isFresh () {
@@ -570,7 +570,7 @@ class SimulatorXcode6 {
   }
 }
 
-for (let [cmd, fn] of _.pairs(extensions)) {
+for (let [cmd, fn] of _.toPairs(extensions)) {
   SimulatorXcode6.prototype[cmd] = fn;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -74,7 +74,7 @@ async function simExists (udid) {
   // see the README for github.com/appium/node-simctl for example output of getDevices()
   let devices = await getDevices();
 
-  devices = _.pairs(devices).map((pair) => {
+  devices = _.toPairs(devices).map((pair) => {
     return pair[1];
   }).reduce((a, b) => {
     return a.concat(b);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.34",
-    "lodash": "^3.10.0",
+    "lodash": "^4.0.0",
     "node-simctl": "^3.2.0",
     "semver-compare": "^1.0.0",
     "source-map-support": "^0.3.2",

--- a/test/unit/simulator-common-specs.js
+++ b/test/unit/simulator-common-specs.js
@@ -16,7 +16,7 @@ let simulatorClasses = {
   'SimulatorXcode7': SimulatorXcode7
 };
 
-for (let [name, simClass] of _.pairs(simulatorClasses)) {
+for (let [name, simClass] of _.toPairs(simulatorClasses)) {
   describe(`common methods - ${name}`, () => {
     let sim;
     beforeEach(() => {


### PR DESCRIPTION
Updating the locale is a slow process (requiring restart of the device, for instance). So only do it if there are actually changes.

Also, update `lodash`.