### PR TITLE
Clean up logging

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -58,7 +58,6 @@ async function plistPaths (sim, identifier) {
 }
 
 async function updateSettings (sim, plist, updates) {
-  log.debug(`Updating settings for '${plist}'`);
   let paths = await plistPaths(sim, plist);
   for (let path of paths) {
     await update(path, updates);
@@ -69,9 +68,6 @@ async function updateSettings (sim, plist, updates) {
 // pass in an object, all settings specified in the object will be
 // updated on the plist, all others left as-is
 async function update (pathToPlist, updates) {
-  log.debug(`Updating settings for '${pathToPlist}'`);
-  log.debug(`    ${JSON.stringify(updates)}`);
-
   let currentSettings = await read(pathToPlist);
   let newSettings = _.merge(currentSettings, updates);
   await plist.updatePlistFile(pathToPlist, newSettings, true, false);
@@ -80,7 +76,6 @@ async function update (pathToPlist, updates) {
 }
 
 async function readSettings (sim, plist) {
-  log.debug(`Retrieving settings for '${plist}'`);
   let settings = {};
   let paths = await plistPaths(sim, plist);
   for (let path of paths) {
@@ -90,7 +85,6 @@ async function readSettings (sim, plist) {
 }
 
 async function read (pathToPlist) {
-  log.debug(`Retrieving settings for ${pathToPlist}`);
   return await plist.parsePlistFile(pathToPlist, false);
 }
 

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -89,6 +89,7 @@ class SimulatorXcode6 {
    * bundle id.
    */
   async buildBundlePathMap (subDir = 'Data') {
+    log.debug('Building bundle path map');
     let applicationList;
     let pathBundlePair;
     if (await this.getPlatformVersion() === '7.1') {
@@ -178,12 +179,6 @@ class SimulatorXcode6 {
     });
 
     let existences = await asyncmap(files, async (f) => { return fs.hasAccess(f); });
-    for (let i = 0; i < files.length; i++) {
-      if (!existences[i]) {
-        log.debug(`File ${files[i]} not yet found`);
-      }
-    }
-
     return _.compact(existences).length !== files.length;
   }
 
@@ -492,6 +487,7 @@ class SimulatorXcode6 {
     let reqVersion = platformVersion;
     if (!reqVersion) {
       reqVersion = await xcode.getMaxIOSSDK();
+      log.warn(`No platform version set. Using max SDK version: ${reqVersion}`);
       // this will be a number, and possibly an integer (e.g., if max iOS SDK is 9)
       // so turn it into a string and add a .0 if necessary
       if (!_.isString(reqVersion)) {
@@ -534,7 +530,13 @@ class SimulatorXcode6 {
       forceIphone: false,
       forceIpad: false
     }, opts);
-    log.debug(`Getting device string: ${JSON.stringify(opts)}`);
+    let logOpts = {
+      deviceName: opts.deviceName,
+      platformVersion: opts.platformVersion,
+      forceIphone: opts.forceIphone,
+      forceIpad: opts.forceIpad
+    };
+    log.debug(`Getting device string from options: ${JSON.stringify(logOpts)}`);
 
     // short circuit if we already have a device name
     if ((opts.deviceName || '')[0] === '=') {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   },
   "dependencies": {
     "appium-logger": "^2.1.0",
-    "appium-support": "^2.0.9",
+    "appium-support": "^2.0.10",
     "appium-xcode": "^3.1.0",
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.34",
     "lodash": "^4.0.0",
-    "node-simctl": "^3.3.0",
+    "node-simctl": "^3.3.1",
     "semver-compare": "^1.0.0",
     "source-map-support": "^0.3.2",
     "teen_process": "^1.3.0"


### PR DESCRIPTION
Remove log lines that get repeated. Calling code ought to log information that is more informative.