### PR TITLE
Handle boot waiting for iOS 10

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -13,6 +13,10 @@ import { tailUntil } from './tail-until.js';
 import extensions from './extensions/index';
 
 
+const OPEN_TIMEOUT = 3000;
+const STARTUP_TIMEOUT = 60 * 1000;
+const EXTRA_STARTUP_TIME = 2000;
+
 class SimulatorXcode6 {
   constructor (udid, xcodeVersion) {
     this.udid = String(udid);
@@ -186,6 +190,21 @@ class SimulatorXcode6 {
     return stat.state === 'Booted';
   }
 
+  async waitForBoot () {
+    // wait for the simulator to boot
+    // waiting for the simulator status to be 'booted' isn't good enough
+    // it claims to be booted way before finishing loading
+    // let's tail the simulator system log until we see a magic line (this.bootedIndicator)
+    let bootedIndicator = await this.getBootedIndicatorString();
+    await this.tailLogsUntil(bootedIndicator, STARTUP_TIMEOUT);
+
+    // so sorry, but we should wait another two seconds, just to make sure we've really started
+    // we can't look for another magic log line, because they seem to be app-dependent (not system dependent)
+    log.debug(`Waiting an extra ${EXTRA_STARTUP_TIME}ms for the simulator to really finish booting`);
+    await B.delay(EXTRA_STARTUP_TIME);
+    log.debug('Done waiting extra time for simulator');
+  }
+
   async getBootedIndicatorString () {
     let indicator;
     let platformVersion = await this.getPlatformVersion();
@@ -214,10 +233,6 @@ class SimulatorXcode6 {
   }
 
   async run () {
-    const OPEN_TIMEOUT = 3000;
-    const STARTUP_TIMEOUT = 60 * 1000;
-    const EXTRA_STARTUP_TIME = 2000;
-
     // start simulator
     let simulatorApp = path.resolve(await getXcodePath(), 'Applications', this.simulatorApp);
     let args = [simulatorApp, '--args', '-CurrentDeviceUDID', this.udid];
@@ -225,18 +240,8 @@ class SimulatorXcode6 {
     let startTime = Date.now();
     await exec('open', args, {timeout: OPEN_TIMEOUT});
 
-    // wait for the simulator to boot
-    // waiting for the simulator status to be 'booted' isn't good enough
-    // it claims to be booted way before finishing loading
-    // let's tail the simulator system log until we see a magic line (this.bootedIndicator)
-    let bootedIndicator = await this.getBootedIndicatorString();
-    await this.tailLogsUntil(bootedIndicator, STARTUP_TIMEOUT);
+    await this.waitForBoot();
 
-    // so sorry, but we should wait another two seconds, just to make sure we've really started
-    // we can't look for another magic log line, because they seem to be app-dependent (not system dependent)
-    log.debug(`Waiting an extra ${EXTRA_STARTUP_TIME}ms for the simulator to really finish booting`);
-    await B.delay(EXTRA_STARTUP_TIME);
-    log.debug('Done waiting extra time for simulator');
     log.info(`Simulator booted in ${Date.now() - startTime}ms`);
   }
 

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -1,8 +1,30 @@
+import { retryInterval } from 'asyncbox';
+import B from 'bluebird';
 import SimulatorXcode7 from './simulator-xcode-7';
+import log from './logger';
+
+
+const EXTRA_STARTUP_TIME = 5000;
 
 class SimulatorXcode8 extends SimulatorXcode7 {
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
+  }
+
+  async waitForBoot () {
+    // there is no reliable boot indicator in Xcode 8
+    // so check the booted status through simctl
+    await retryInterval(120, 500, async () => {
+      let device = await this.stat();
+      if (!device) throw new Error(`Unable to find simulator with udid '${this.udid}'`);
+      if (device.state !== 'Booted') throw new Error(`Simulator with udid '${this.udid}' is in '${device.state}' state`);
+    });
+
+    // so sorry, but we should wait another two seconds, just to make sure we've really started
+    // we can't look for another magic log line, because they seem to be app-dependent (not system dependent)
+    log.debug(`Waiting an extra ${EXTRA_STARTUP_TIME}ms for the simulator to really finish booting`);
+    await B.delay(EXTRA_STARTUP_TIME);
+    log.debug('Done waiting extra time for simulator');
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.34",
     "lodash": "^4.2.1",
-    "node-simctl": "^3.4.0",
+    "node-simctl": "^3.4.3",
     "semver-compare": "^1.0.0",
     "source-map-support": "^0.4.0",
     "teen_process": "^1.3.0"

--- a/test/simulator-e2e-specs.js
+++ b/test/simulator-e2e-specs.js
@@ -7,6 +7,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { fs } from 'appium-support';
 import B from 'bluebird';
 import getAppPath from 'sample-apps';
+import { retryInterval } from 'asyncbox';
 
 
 const LONG_TIMEOUT = 120*1000;
@@ -101,7 +102,11 @@ function runTests (deviceType) {
 
       // install & launch test app
       await simctl.installApp(udid, getAppPath('TestApp'));
-      await simctl.launch(udid, 'io.appium.TestApp', 1);
+
+      // this remains somewhat flakey
+      await retryInterval(5, 1000, async () => {
+        await simctl.launch(udid, 'io.appium.TestApp', 1);
+      });
 
       await sim.removeApp('io.appium.TestApp');
 


### PR DESCRIPTION
There is no reliable boot message in the logs, so rely on the simctl status, which is not as reliable but better than waiting 60s to timeout.