### PR TITLE
Fix typo in effective settings plist path

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -49,7 +49,7 @@ async function plistPaths (sim, identifier) {
       }
       break;
     case 'effectiveUserSettings':
-      paths.push(path.resolve(simDirectory, 'Libary', 'ConfigurationProfiles', 'EffectiveUserSettings.plist'));
+      paths.push(path.resolve(simDirectory, 'Library', 'ConfigurationProfiles', 'EffectiveUserSettings.plist'));
       paths.push(path.resolve(simDirectory, 'Library', 'ConfigurationProfiles', 'PublicInfo', 'PublicEffectiveUserSettings.plist'));
       break;
   }


### PR DESCRIPTION
I assume "Libary" was incorrect.