### PR TITLE
map bare 'iPad Simulator' to 'iPad Retina' in ios 10

### DIFF
--- a/lib/simulator-xcode-7.js
+++ b/lib/simulator-xcode-7.js
@@ -23,6 +23,8 @@ class SimulatorXcode7 extends SimulatorXcode6 {
       'iPad Simulator (9.1)': 'iPad 2 (9.1)',
       'iPad Simulator (9.2)': 'iPad 2 (9.2)',
       'iPad Simulator (9.3)': 'iPad 2 (9.3)',
+      'iPad Simulator (10.0)': 'iPad Retina',
+      'iPad Simulator (10.1)': 'iPad Retina',
       'iPhone Simulator (8.1)': 'iPhone 6 (8.1)',
       'iPhone Simulator (8.2)': 'iPhone 6 (8.2)',
       'iPhone Simulator (8.3)': 'iPhone 6 (8.3)',


### PR DESCRIPTION
part of appium/appium#7122

cc @imurchie 
