### PR TITLE
Log errors if invalid UDID or openssl not on path

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -169,7 +169,8 @@ async function uninstallSSLCert (pemText, udid) {
     await fs.unlink(tempFileName);
     return certificate;
   } catch (e) {
-
+    log.debug(`Could not uninstall SSL certificate. No simulator with udid '${udid}'`);
+    log.errorAndThrow(e);
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -134,22 +134,43 @@ async function safeRimRaf (delPath, tryNum = 0) {
   }
 }
 
+
 async function installSSLCert (pemText, udid) {
+  // Check that openssl is installed on the path
+  try {
+    await exec('which', ['openssl']);
+  } catch (e) {
+    log.debug(`customSSLCert requires openssl to be available on path`);
+    log.errorAndThrow(`Command 'openssl' not found`);
+  }
+
   let tempFileName = path.resolve(`${__dirname}/temp-ssl-cert.pem`);
   let pathToKeychain = path.resolve(new Simulator(udid).getDir());
   await fs.writeFile(tempFileName, pemText);
+  try {
+    await fs.stat(pathToKeychain);
+  } catch (e) {
+    log.debug(`Could not install SSL certificate. No simulator with udid '${udid}'`); 
+    log.errorAndThrow(e);
+  }
   let certificate = new Certificate(tempFileName);
   await certificate.add(pathToKeychain);
-  return await fs.unlink(tempFileName);
+  await fs.unlink(tempFileName);
+  return certificate; 
 }
 
 async function uninstallSSLCert (pemText, udid) {
-  let tempFileName = path.resolve(`${__dirname}/temp-ssl-cert.pem`);
-  let pathToKeychain = path.resolve(new Simulator(udid).getDir());
-  await fs.writeFile(tempFileName, pemText);
-  let certificate = new Certificate(tempFileName);
-  await certificate.remove(pathToKeychain);
-  return await fs.unlink(tempFileName);
+  try {
+    let tempFileName = path.resolve(`${__dirname}/temp-ssl-cert.pem`);
+    let pathToKeychain = path.resolve(new Simulator(udid).getDir());
+    await fs.writeFile(tempFileName, pemText);
+    let certificate = new Certificate(tempFileName);
+    await certificate.remove(pathToKeychain);
+    await fs.unlink(tempFileName);
+    return certificate;
+  } catch (e) {
+
+  }
 }
 
 export { killAllSimulators, endAllSimulatorDaemons, safeRimRaf, simExists, installSSLCert, uninstallSSLCert };

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -139,8 +139,12 @@ describe('installSSLCert and uninstallSSLCert', () => {
     execStub.restore();
   });
 
-  it('should throw exception if udid is invalid', async () => {
+  it('should throw exception on installSSLCert if udid is invalid', async () => {
     await installSSLCert('pem dummy text', 'invalid UDID').should.be.rejected;
+  });
+
+  it('should throw exception on uninstallSSLCert if udid is invalid', async () => {
+    await uninstallSSLCert('pem dummy text', 'invalid UDID').should.be.rejected;
   });
 
 });


### PR DESCRIPTION
- If the user provides an invalid UDID, throw a descriptive expression
- Checks if openssl is available. If openssl is not on path, throw an error message telling users that it is required
- InstallSSLCert returns instance of Certificate object now for testing purposes
- Add tests to installSSLCert and uninstallSSLCert
- Installs cert locally, checks that it's there, uninstalls it, checks that it's gone
- Checks that exceptions are thrown correctly