### PR TITLE
Use different startup timeout for iOS 10+

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -49,6 +49,10 @@ class SimulatorXcode6 {
     this.extraStartupTime = EXTRA_STARTUP_TIME;
   }
 
+  get startupTimeout () {
+    return STARTUP_TIMEOUT;
+  }
+
   setScaleFactor (newScaleFactor) {
     let supportedScales = ['1.0', '0.75', '0.5', '0.33', '0.25'];
     if (supportedScales.indexOf(newScaleFactor) < 0) {
@@ -249,8 +253,7 @@ class SimulatorXcode6 {
     return indicator;
   }
 
-  async run (startupTimeout = STARTUP_TIMEOUT) {
-    // start simulator
+  async run (startupTimeout = this.startupTimeout) {
     let simulatorApp = path.resolve(await getXcodePath(), 'Applications', this.simulatorApp);
     let args = ['-Fn', simulatorApp, '--args', '-CurrentDeviceUDID', this.udid];
     if (this.scaleFactor) {

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -2,6 +2,9 @@ import SimulatorXcode7 from './simulator-xcode-7';
 import log from './logger';
 
 
+// these sims are sloooooooow
+const STARTUP_TIMEOUT = 120 * 1000;
+
 class SimulatorXcode8 extends SimulatorXcode7 {
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
@@ -19,6 +22,10 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     this.extraStartupTime = 10000;
   }
 
+  get startupTimeout () {
+    return STARTUP_TIMEOUT;
+  }
+
   async getBootedIndicatorString () {
     let indicator;
     let platformVersion = await this.getPlatformVersion();
@@ -32,7 +39,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       case '10.0':
       case '10.1':
       case '10.2':
-        indicator = 'com.apple.springboard';
+        indicator = 'SMS Plugin initialized';
         break;
       default:
         log.warn(`No boot indicator case for platform version '${platformVersion}'`);

--- a/lib/tail-until.js
+++ b/lib/tail-until.js
@@ -16,18 +16,16 @@ async function tailUntil (filePath, until, timeout = 5000) {
     return stdout.indexOf(until) > -1;
   };
 
-  return new B(async (resolve, reject) => {
+  return await new B((resolve, reject) => {
     let started = proc.start(startDetector);
 
     /* eslint-disable promise/prefer-await-to-then */
     let timedout = B.delay(timeout).then(() => {
-      return reject(`tailing file ${filePath} failed after ${timeout}ms`);
+      return reject(new Error(`Tailing file ${filePath} failed after ${timeout}ms`));
     });
     /* eslint-enable */
 
-    await B.race([started, timedout]);
-
-    resolve();
+    B.race([started, timedout]).then(resolve).catch(reject);
   }).finally(async () => {
     // no matter what, stop the tail process
     if (proc.isRunning) {


### PR DESCRIPTION
Make the startup timeout dynamic, so that iOS 10+ sims can have a longer one. Why oh why is the simulator boot so slow?

This seems to fix, locally at least, the XCUITest issue in which `xcodebuild` errors out with `"Early unexpected exit, operation never finished bootstrapping - no restart will be attempted"`. This seems to happen when the device is not quite ready to get installed to.