### PR TITLE
TrustStore creates keychains folder if none exists

### DIFF
--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -133,7 +133,14 @@ class TrustStore {
 
     // If it doesn't have a tsettings table, create one
     await this.db.runAsync(`
-      CREATE TABLE IF NOT EXISTS tsettings(sha1 BLOB NOT NULL DEFAULT '',subj BLOB NOT NULL DEFAULT '',tset BLOB,data BLOB,PRIMARY KEY(sha1)); 
+      CREATE TABLE IF NOT EXISTS tsettings (
+        sha1 BLOB NOT NULL DEFAULT '',
+        subj BLOB NOT NULL DEFAULT '',
+        tset BLOB,
+        data 
+        BLOB,
+        PRIMARY KEY(sha1)
+      ); 
       CREATE INDEX isubj ON tsettings(subj);
     `);
 

--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import B from 'bluebird';
 import path from 'path';
+import { fs, mkdirp } from 'appium-support';
 
 const sqlite3 = B.promisifyAll(require('sqlite3'));
 const openssl = B.promisify(require('openssl-wrapper').exec);
@@ -46,7 +47,7 @@ class Certificate {
   /**
    * Remove certificate from the TrustStore
    */
-  async remove (dir) { 
+  async remove (dir) {
     let subject = await this.getSubject(this.pemFilename);
     let trustStore = new TrustStore(dir);
     return trustStore.removeRecord(subject);
@@ -110,8 +111,33 @@ class Certificate {
  */
 class TrustStore {
   constructor (sharedResourceDir) {
-    this.sqliteDBPath = path.resolve(sharedResourceDir, 'Library/Keychains/TrustStore.sqlite3');
-    this.db = new sqlite3.Database(this.sqliteDBPath);
+    this.sharedResourceDir = sharedResourceDir;
+  }
+
+  /**
+   * Get TrustStore database associated with this simulator
+   */
+  async getDB () {
+    if (this.db) {
+      return this.db;
+    }
+
+    // If the sim doesn't have a keychains directory, create one
+    let keychainsPath = path.resolve(this.sharedResourceDir, 'Library', 'Keychains');
+    if (!(await fs.exists(keychainsPath))) {
+      await mkdirp(keychainsPath);
+    }
+
+    // Open sqlite database
+    this.db = new sqlite3.Database(path.resolve(keychainsPath, 'TrustStore.sqlite3'));
+
+    // If it doesn't have a tsettings table, create one
+    await this.db.runAsync(`
+      CREATE TABLE IF NOT EXISTS tsettings(sha1 BLOB NOT NULL DEFAULT '',subj BLOB NOT NULL DEFAULT '',tset BLOB,data BLOB,PRIMARY KEY(sha1)); 
+      CREATE INDEX isubj ON tsettings(subj);
+    `);
+
+    return this.db; 
   }
 
   /**
@@ -119,10 +145,11 @@ class TrustStore {
    */
   async addRecord (sha1, tset, subj, data) {
     let existingRecords = await this.getRecords(subj);
+    let db = await this.getDB();
     if (existingRecords.length > 0) {
-      return await this.db.runAsync(`UPDATE tsettings SET sha1=?, tset=?, data=? WHERE subj=?`, [sha1, tset, data, subj]);
+      return await db.runAsync(`UPDATE tsettings SET sha1=?, tset=?, data=? WHERE subj=?`, [sha1, tset, data, subj]);
     } else {
-      return await this.db.runAsync(`INSERT INTO tsettings (sha1, subj, tset, data) VALUES (?, ?, ?, ?)`, [sha1, subj, tset, data]);
+      return await db.runAsync(`INSERT INTO tsettings (sha1, subj, tset, data) VALUES (?, ?, ?, ?)`, [sha1, subj, tset, data]);
     }
   }
 
@@ -130,14 +157,16 @@ class TrustStore {
    * Remove record from tsettings
    */
   async removeRecord (subj) {
-    return this.db.runAsync(`DELETE FROM tsettings WHERE subj = ?`, [subj]);
+    let db = await this.getDB();
+    return await db.runAsync(`DELETE FROM tsettings WHERE subj = ?`, [subj]);
   }
 
   /**
    * Get a record from tsettings
    */
   async getRecords (subj) {
-    return this.db.allAsync(`SELECT * FROM tsettings WHERE subj = ?`, [subj]);
+    let db = await this.getDB();
+    return await db.allAsync(`SELECT * FROM tsettings WHERE subj = ?`, [subj]);
   } 
 }
 


### PR DESCRIPTION
If there is no keychains folder at the TrustStore library, create one and create a new sqlite db with a tsettings table

**Reviewers: @jlipps @imurchie**