### PR TITLE
Lazy load the sqlite3 module

### DIFF
--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -2,23 +2,41 @@ import crypto from 'crypto';
 import B from 'bluebird';
 import path from 'path';
 import { fs, mkdirp } from 'appium-support';
+import log from './logger';
 
-const sqlite3 = B.promisifyAll(require('sqlite3'));
-const openssl = B.promisify(require('openssl-wrapper').exec);
 
-let tset = `<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n
+// these will be lazily loaded, because the sqlite3 module installation is
+// fragile and often doesn't load. we don't want the error message unless
+// the user actually tries to use the certificate functionality
+let sqlite3;
+let openssl;
+
+function loadSqlite3 () {
+  try {
+    sqlite3 = B.promisifyAll(require('sqlite3'));
+    openssl = B.promisify(require('openssl-wrapper').exec);
+  } catch (err) {
+    log.errorAndThrow(`Unable to load sqlite3 module: ${err.message}.`);
+  }
+}
+
+const tset = `<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n
     <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
     <plist version=\"1.0\">
     <array/>
 </plist>`;
 
 /**
- * Library for programatically adding certificates 
+ * Library for programatically adding certificates
  */
 class Certificate {
 
-  constructor (pemFilename) { 
+  constructor (pemFilename) {
     this.pemFilename = pemFilename;
+
+    // there is no point in going further in the process if we can't access the
+    // necessary sqlite3 module
+    loadSqlite3();
   }
 
   /**
@@ -62,7 +80,7 @@ class Certificate {
     }
 
     // Convert 'pem' file to 'der'
-    this.data = await openssl('x509', { 
+    this.data = await openssl('x509', {
       outform: 'der',
       in: this.pemFilename
     });
@@ -92,7 +110,7 @@ class Certificate {
     if (this.subject) {
       return this.subject;
     }
-      
+
     // Convert 'pem' file to 'der'
     let subject = await openssl('x509', {
       noout: true,
@@ -100,7 +118,7 @@ class Certificate {
       in: this.pemFilename
     });
     let subRegex = /^subject[\w\W]*\/CN=([\w\W]*)(\n)?/;
-    this.subject = subject.toString().match(subRegex)[1]; 
+    this.subject = subject.toString().match(subRegex)[1];
     return this.subject;
   }
 
@@ -112,6 +130,10 @@ class Certificate {
 class TrustStore {
   constructor (sharedResourceDir) {
     this.sharedResourceDir = sharedResourceDir;
+
+    // there is no point in going further in the process if we can't access the
+    // necessary sqlite3 module
+    loadSqlite3();
   }
 
   /**
@@ -137,14 +159,14 @@ class TrustStore {
         sha1 BLOB NOT NULL DEFAULT '',
         subj BLOB NOT NULL DEFAULT '',
         tset BLOB,
-        data 
+        data
         BLOB,
         PRIMARY KEY(sha1)
-      ); 
+      );
       CREATE INDEX isubj ON tsettings(subj);
     `);
 
-    return this.db; 
+    return this.db;
   }
 
   /**
@@ -174,8 +196,8 @@ class TrustStore {
   async getRecords (subj) {
     let db = await this.getDB();
     return await db.allAsync(`SELECT * FROM tsettings WHERE subj = ?`, [subj]);
-  } 
+  }
 }
 
 export default Certificate;
-export { Certificate, TrustStore }; 
+export { Certificate, TrustStore };

--- a/test/unit/certificate-specs.js
+++ b/test/unit/certificate-specs.js
@@ -34,7 +34,7 @@ describe('when using TrustStore class', () => {
     let tsettings = await trustStore.getRecords(testUUID);
     expect(tsettings).to.have.length.of(0);
     await trustStore.addRecord(uuid.v4(), 'tset', testUUID, 'data');
-    tsettings = await trustStore.getRecords(testUUID); 
+    tsettings = await trustStore.getRecords(testUUID);
     expect(tsettings).to.have.length.above(0);
     tsettings[0].subj.should.equal(testUUID);
   });
@@ -45,7 +45,7 @@ describe('when using TrustStore class', () => {
     expect(tsettings).to.have.length.above(0);
     await trustStore.removeRecord(testUUID);
     tsettings = await trustStore.getRecords(testUUID);
-    expect(tsettings).to.have.length(0); 
+    expect(tsettings).to.have.length(0);
   });
 
   it('can update a record in the TrustStore tsettings', async () => {
@@ -54,7 +54,7 @@ describe('when using TrustStore class', () => {
     expect(tsettings[0].data).to.equal('data1');
     await trustStore.addRecord(uuid.v4(), 'tset', testUUID, 'data2');
     tsettings = await trustStore.getRecords(testUUID);
-    expect(tsettings[0].data).to.equal('data2');  
+    expect(tsettings[0].data).to.equal('data2');
   });
 });
 
@@ -62,7 +62,7 @@ describe('when using TrustStore class when the keychains directory doesn\'t exis
   beforeEach(async () => {
     tempDirectory = `${assetsDir}/temp`;
     await fs.rimraf(tempDirectory);
-    await fs.mkdir(tempDirectory); 
+    await fs.mkdir(tempDirectory);
   });
 
   afterEach(async () => {
@@ -86,13 +86,13 @@ describe('when using Certificate class', () => {
   it('can translate PEM certificate to DER format', async () => {
     let derData = await certificate.getDerData();
     let testData = await fs.readFile(`${assetsDir}/Library/certificates/test-data.txt`);
-    expect(testData.equals(derData)); 
+    expect(testData.equals(derData));
   });
- 
+
   it('can get a fingerprint from a PEM certificate', async () => {
     let fingerprint = await certificate.getFingerPrint();
     let testFingerprint = await fs.readFile(`${assetsDir}/Library/certificates/test-fingerprint.txt`);
-    expect(fingerprint.equals(testFingerprint));   
+    expect(fingerprint.equals(testFingerprint));
   });
 
   it('can get a subject from a PEM certificate', async () => {
@@ -105,7 +105,7 @@ describe('when using Certificate class', () => {
     await certificate.add(assetsDir);
     let hasCert = await certificate.has(assetsDir);
     expect(hasCert);
-  });  
+  });
 
   it('can add and remove a certificate to a sqlite store', async () => {
     await certificate.add(assetsDir);
@@ -121,7 +121,7 @@ describe('when using Certificate class', () => {
     let hasCert = await certificate.has(assetsDir);
     expect(hasCert);
 
-    certificate = new Certificate(`${assetsDir}/test-pem.pem`); 
+    certificate = new Certificate(`${assetsDir}/test-pem.pem`);
     await certificate.remove(assetsDir);
     hasCert = await certificate.has(assetsDir);
     expect(!hasCert);


### PR DESCRIPTION
The `sqlite3` module seems to have problems that are hard to pin down, finding the native library it uses (see, for instance, https://github.com/appium/appium/issues/7624). Rather than globally load the module, wait until it is needed, so that the only people affected are the people that need it, and it effort can be made to fix it for them, rather than for lots of people for whom the whole thing is irrelevant.