### PR TITLE
Fix cleanCustomApp to be able to retain app

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -278,10 +278,23 @@ class SimulatorXcode6 {
     await simctl.eraseDevice(this.udid, 10000);
   }
 
-  async cleanCustomApp (appFile, appBundleId) {
-    log.debug(`Cleaning app data files for '${appFile}', '${appBundleId}'`);
+  async scrubCustomApp (appFile, appBundleId) {
+    return await this.cleanCustomApp (appFile, appBundleId, true);
+  }
 
-    let appDirs = await this.getAppDirs(appFile, appBundleId);
+  async cleanCustomApp (appFile, appBundleId, scrub = false) {
+    // if `scrub` is false, we want to clean by deleting the app and all
+    // files associated with it
+    // if `scrub` is true, we just want to delete the preferences and changed
+    // files
+
+    log.debug(`Cleaning app data files for '${appFile}', '${appBundleId}'`);
+    if (!scrub) {
+      log.debug(`Deleting app altogether`);
+    }
+
+    // get the directories to be deleted
+    let appDirs = await this.getAppDirs(appFile, appBundleId, scrub);
 
     if (appDirs.length === 0) {
       log.debug("Could not find app directories to delete. It is probably not installed");
@@ -305,18 +318,21 @@ class SimulatorXcode6 {
     await B.all(deletePromises);
   }
 
-  async getAppDirs (appFile, appBundleId) {
+  async getAppDirs (appFile, appBundleId, scrub = false) {
     let dirs = [];
     // iOS 8+ stores app data in two places,
     // iOS 7.1 has only one directory
     if (await this.getPlatformVersion() >= 8) {
       let data = await this.getAppDir(appBundleId);
-      let bundle = await this.getAppDir(appBundleId, 'Bundle');
-      if (data) {
-        dirs.push(data);
-      }
-      if (bundle) {
-        dirs.push(bundle);
+
+      // the `Bundle` directory has the actual app in it. If we are just scrubbing,
+      // we want this to stay. If we are cleaning we delete
+      let bundle = !scrub ? await this.getAppDir(appBundleId, 'Bundle') : undefined;
+
+      for (let src of [data, bundle]) {
+        if (src) {
+          dirs.push(src);
+        }
       }
     } else {
       let data = await this.getAppDir(appFile);

--- a/test/simulator-e2e-specs.js
+++ b/test/simulator-e2e-specs.js
@@ -104,7 +104,7 @@ function runTests (deviceType) {
       await sim.run();
 
       let error = /The operation couldn’t be completed/;
-      if (parseInt(process.env.DEVICE, 10) >= 10) {
+      if ((process.env.DEVICE && parseInt(process.env.DEVICE, 10) >= 10) || (deviceType.version && parseInt(deviceType.version, 10) >= 10)) {
         error = /The request was denied by service delegate/;
       }
 
@@ -285,37 +285,18 @@ if (!process.env.TRAVIS && !process.env.DEVICE) {
       version: '9.0',
       device: 'iPhone 6s'
     },
-    {
-      version: '9.1',
-      device: 'iPhone 6s'
-    }
   ];
 } else {
   // on travis, we want to just do what we specify
   // travis also cannot at the moment create 9.0 and 9.1 sims
   // so only do these if testing somewhere else
-  if (process.env.DEVICE === '9.3') {
-    deviceTypes = [
-      {
-        version: '9.3',
-        device: 'iPhone 6s'
-      }
-    ];
-  } else if (process.env.DEVICE === '9.2') {
-    deviceTypes = [
-      {
-        version: '9.2',
-        device: 'iPhone 6s'
-      }
-    ];
-  } else if (process.env.DEVICE === '10' || process.env.DEVICE === '10.0') {
-    deviceTypes = [
-      {
-        version: '10.0',
-        device: 'iPhone 6s'
-      }
-    ];
-  }
+  let version = (process.env.DEVICE === '10' || process.env.DEVICE === '10.0') ? '10.0' : process.env.DEVICE;
+  deviceTypes = [
+    {
+      version,
+      device: 'iPhone 6s'
+    }
+  ];
 }
 
 for (let deviceType of deviceTypes) {


### PR DESCRIPTION
Make sure that if we want to, we do not delete the app when cleaning a custom app. This will allow us to do a "fast reset" easily.

See https://github.com/appium/appium/issues/7754