### PR TITLE
Removed sqlite3 dependency

### DIFF
--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -2,27 +2,13 @@ import crypto from 'crypto';
 import B from 'bluebird';
 import path from 'path';
 import { fs, mkdirp } from 'appium-support';
-import log from './logger';
+import { exec } from 'teen_process';
 
+const openssl = B.promisify(require('openssl-wrapper').exec);
 
-// these will be lazily loaded, because the sqlite3 module installation is
-// fragile and often doesn't load. we don't want the error message unless
-// the user actually tries to use the certificate functionality
-let sqlite3;
-let openssl;
-
-function loadSqlite3 () {
-  try {
-    sqlite3 = B.promisifyAll(require('sqlite3'));
-    openssl = B.promisify(require('openssl-wrapper').exec);
-  } catch (err) {
-    log.errorAndThrow(`Unable to load sqlite3 module: ${err.message}.`);
-  }
-}
-
-const tset = `<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n
-    <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
-    <plist version=\"1.0\">
+const tset = `<?xml version="1.0" encoding="UTF-8"?>\n
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
     <array/>
 </plist>`;
 
@@ -33,22 +19,18 @@ class Certificate {
 
   constructor (pemFilename) {
     this.pemFilename = pemFilename;
-
-    // there is no point in going further in the process if we can't access the
-    // necessary sqlite3 module
-    loadSqlite3();
   }
 
   /**
    * Add a certificate to the TrustStore
    */
   async add (dir) {
-    let data = await this.getDerData(this.pemFilename);
-    let subject = await this.getSubject(this.pemFilename);
-    let fingerprint = await this.getFingerPrint(this.data);
+    let data = (await this.getDerData(this.pemFilename)).toString('hex'); 
+    let subject = (await this.getSubject(this.pemFilename));
+    let sha1 = (await this.getFingerPrint(this.data)).toString('hex');
 
     let trustStore = new TrustStore(dir);
-    return trustStore.addRecord(fingerprint, tset, subject, data);
+    return trustStore.addRecord(sha1, tset, subject, data);
   }
 
   /**
@@ -56,10 +38,8 @@ class Certificate {
    */
   async has (dir) {
     let subject = await this.getSubject(this.pemFilename);
-
     let trustStore = new TrustStore(dir);
-    let records = await trustStore.getRecords(subject);
-    return records.length > 0;
+    return await trustStore.hasRecords(subject);
   }
 
   /**
@@ -130,10 +110,6 @@ class Certificate {
 class TrustStore {
   constructor (sharedResourceDir) {
     this.sharedResourceDir = sharedResourceDir;
-
-    // there is no point in going further in the process if we can't access the
-    // necessary sqlite3 module
-    loadSqlite3();
   }
 
   /**
@@ -151,34 +127,26 @@ class TrustStore {
     }
 
     // Open sqlite database
-    this.db = new sqlite3.Database(path.resolve(keychainsPath, 'TrustStore.sqlite3'));
+    this.db = path.resolve(keychainsPath, 'TrustStore.sqlite3');
 
     // If it doesn't have a tsettings table, create one
-    await this.db.runAsync(`
-      CREATE TABLE IF NOT EXISTS tsettings (
-        sha1 BLOB NOT NULL DEFAULT '',
-        subj BLOB NOT NULL DEFAULT '',
-        tset BLOB,
-        data
-        BLOB,
-        PRIMARY KEY(sha1)
-      );
-      CREATE INDEX isubj ON tsettings(subj);
-    `);
+    await this.execSQLiteQuery(`CREATE TABLE IF NOT EXISTS tsettings (sha1 BLOB NOT NULL DEFAULT '', subj BLOB NOT NULL DEFAULT '', tset BLOB, data BLOB, PRIMARY KEY(sha1));`); 
+    try {
+      await this.execSQLiteQuery('CREATE INDEX isubj ON tsettings(subj);');
+    } catch (e) { }
+    
 
-    return this.db;
+    return this.db; 
   }
 
   /**
    * Add record to tsettings
    */
   async addRecord (sha1, tset, subj, data) {
-    let existingRecords = await this.getRecords(subj);
-    let db = await this.getDB();
-    if (existingRecords.length > 0) {
-      return await db.runAsync(`UPDATE tsettings SET sha1=?, tset=?, data=? WHERE subj=?`, [sha1, tset, data, subj]);
+    if (await this.hasRecords(subj)) {
+      return await this.execSQLiteQuery(`UPDATE tsettings SET sha1=x'?', tset='?', data=x'?' WHERE subj='?'`, sha1, tset, data, subj);
     } else {
-      return await db.runAsync(`INSERT INTO tsettings (sha1, subj, tset, data) VALUES (?, ?, ?, ?)`, [sha1, subj, tset, data]);
+      return await this.execSQLiteQuery(`INSERT INTO tsettings (sha1, subj, tset, data) VALUES (x'?', '?', '?', x'?')`, sha1, subj, tset, data);
     }
   }
 
@@ -186,16 +154,39 @@ class TrustStore {
    * Remove record from tsettings
    */
   async removeRecord (subj) {
-    let db = await this.getDB();
-    return await db.runAsync(`DELETE FROM tsettings WHERE subj = ?`, [subj]);
+    return await this.execSQLiteQuery(`DELETE FROM tsettings WHERE subj = '?'`, subj);
   }
 
   /**
    * Get a record from tsettings
    */
-  async getRecords (subj) {
+  async hasRecords (subj) {
+    return (await this.getRecordCount(subj)) > 0;
+  } 
+
+  async getRecordCount (subj) {
+    let result =  (await this.execSQLiteQuery(`SELECT count(*) FROM tsettings WHERE subj = '?'`, subj)).stdout;
+    return parseInt(result.split('=')[1], 10);
+  }
+
+  escapeQuery (query) {
+    return query.replace(/'/g, "''");
+  }
+
+  /**
+   * Runs a command line sqlite3 query
+   */
+  async execSQLiteQuery (query, ...queryParams) {
+    let queryTokens = query.split('?');
+    let formattedQuery = [];
+    queryParams.forEach((param, i) => {
+      formattedQuery.push(queryTokens[i]);
+      formattedQuery.push(this.escapeQuery(param));
+    }); 
+    formattedQuery.push(queryTokens[queryTokens.length - 1]); 
+
     let db = await this.getDB();
-    return await db.allAsync(`SELECT * FROM tsettings WHERE subj = ?`, [subj]);
+    return await exec('sqlite3', ['-line', db, formattedQuery.join('')]);
   }
 }
 

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -278,10 +278,23 @@ class SimulatorXcode6 {
     await simctl.eraseDevice(this.udid, 10000);
   }
 
-  async cleanCustomApp (appFile, appBundleId) {
-    log.debug(`Cleaning app data files for '${appFile}', '${appBundleId}'`);
+  async scrubCustomApp (appFile, appBundleId) {
+    return await this.cleanCustomApp (appFile, appBundleId, true);
+  }
 
-    let appDirs = await this.getAppDirs(appFile, appBundleId);
+  async cleanCustomApp (appFile, appBundleId, scrub = false) {
+    // if `scrub` is false, we want to clean by deleting the app and all
+    // files associated with it
+    // if `scrub` is true, we just want to delete the preferences and changed
+    // files
+
+    log.debug(`Cleaning app data files for '${appFile}', '${appBundleId}'`);
+    if (!scrub) {
+      log.debug(`Deleting app altogether`);
+    }
+
+    // get the directories to be deleted
+    let appDirs = await this.getAppDirs(appFile, appBundleId, scrub);
 
     if (appDirs.length === 0) {
       log.debug("Could not find app directories to delete. It is probably not installed");
@@ -305,18 +318,21 @@ class SimulatorXcode6 {
     await B.all(deletePromises);
   }
 
-  async getAppDirs (appFile, appBundleId) {
+  async getAppDirs (appFile, appBundleId, scrub = false) {
     let dirs = [];
     // iOS 8+ stores app data in two places,
     // iOS 7.1 has only one directory
     if (await this.getPlatformVersion() >= 8) {
       let data = await this.getAppDir(appBundleId);
-      let bundle = await this.getAppDir(appBundleId, 'Bundle');
-      if (data) {
-        dirs.push(data);
-      }
-      if (bundle) {
-        dirs.push(bundle);
+
+      // the `Bundle` directory has the actual app in it. If we are just scrubbing,
+      // we want this to stay. If we are cleaning we delete
+      let bundle = !scrub ? await this.getAppDir(appBundleId, 'Bundle') : undefined;
+
+      for (let src of [data, bundle]) {
+        if (src) {
+          dirs.push(src);
+        }
       }
     } else {
       let data = await this.getAppDir(appFile);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,7 +146,7 @@ async function installSSLCert (pemText, udid) {
 
   // Check that sqlite3 is installed on the path
   try {
-    await exec('which', ['sqlite3']);
+    await fs.which('sqlite3');
   } catch (e) {
     log.debug(`customSSLCert requires sqlite3 to be available on path`);
     log.errorAndThrow(`Command 'sqlite3' not found`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -144,8 +144,16 @@ async function installSSLCert (pemText, udid) {
     log.errorAndThrow(`Command 'openssl' not found`);
   }
 
-  let tempFileName = path.resolve(__dirname, 'temp-ssl-cert.pem');
-  let pathToKeychain = new Simulator(udid).getDir();
+  // Check that sqlite3 is installed on the path
+  try {
+    await exec('which', ['sqlite3']);
+  } catch (e) {
+    log.debug(`customSSLCert requires sqlite3 to be available on path`);
+    log.errorAndThrow(`Command 'sqlite3' not found`);
+  }
+
+  let tempFileName = path.resolve(`${__dirname}/temp-ssl-cert.pem`);
+  let pathToKeychain = path.resolve(new Simulator(udid).getDir());
   await fs.writeFile(tempFileName, pemText);
   try {
     await fs.stat(pathToKeychain);
@@ -154,6 +162,7 @@ async function installSSLCert (pemText, udid) {
     log.errorAndThrow(e);
   }
   let certificate = new Certificate(tempFileName);
+  log.debug(`Installing certificate to ${pathToKeychain}`);
   await certificate.add(pathToKeychain);
   await fs.unlink(tempFileName);
   return certificate;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "openssl-wrapper": "^0.3.4",
     "semver-compare": "^1.0.0",
     "source-map-support": "^0.4.0",
-    "sqlite3": "^3.1.8",
     "teen_process": "^1.3.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "appium"
   ],
-  "version": "1.10.3",
+  "version": "1.11.0",
   "author": "appium",
   "license": "Apache-2.0",
   "repository": {

--- a/test/assets/certificate-test-server/server.js
+++ b/test/assets/certificate-test-server/server.js
@@ -1,14 +1,10 @@
 /* eslint-disable no-console */
 import https from 'https';
 import inquirer from 'inquirer';
-
 import { installSSLCert, uninstallSSLCert } from '../../../lib/utils';
 import { getDevices } from 'node-simctl';
 import B from 'bluebird';
-
-/* jshint ignore:start */ /* eslint-disable no-unused-vars */
-import colors from 'colors';
-/* eslint-enable */ /* jshint ignore:end */
+import 'colors';
 
 const pem = B.promisifyAll(require('pem'));
 
@@ -45,6 +41,7 @@ const pem = B.promisifyAll(require('pem'));
   let bootedDevice = bootedDevices[0];
   let udid = bootedDevice.udid;
   let deviceName = bootedDevice.name;
+  console.log(`Using bootedDevice ${udid}`);
 
   console.log('HTTPS server is running at localhost:9758 and has created a new certificate at "random-pem.pem"'.yellow);  
   console.log(`Navigate to https://localhost:9758 in '${deviceName} Simulator'`.yellow);

--- a/test/simulator-e2e-specs.js
+++ b/test/simulator-e2e-specs.js
@@ -104,7 +104,7 @@ function runTests (deviceType) {
       await sim.run();
 
       let error = /The operation couldn’t be completed/;
-      if (parseInt(process.env.DEVICE, 10) >= 10) {
+      if ((process.env.DEVICE && parseInt(process.env.DEVICE, 10) >= 10) || (deviceType.version && parseInt(deviceType.version, 10) >= 10)) {
         error = /The request was denied by service delegate/;
       }
 
@@ -285,37 +285,18 @@ if (!process.env.TRAVIS && !process.env.DEVICE) {
       version: '9.0',
       device: 'iPhone 6s'
     },
-    {
-      version: '9.1',
-      device: 'iPhone 6s'
-    }
   ];
 } else {
   // on travis, we want to just do what we specify
   // travis also cannot at the moment create 9.0 and 9.1 sims
   // so only do these if testing somewhere else
-  if (process.env.DEVICE === '9.3') {
-    deviceTypes = [
-      {
-        version: '9.3',
-        device: 'iPhone 6s'
-      }
-    ];
-  } else if (process.env.DEVICE === '9.2') {
-    deviceTypes = [
-      {
-        version: '9.2',
-        device: 'iPhone 6s'
-      }
-    ];
-  } else if (process.env.DEVICE === '10' || process.env.DEVICE === '10.0') {
-    deviceTypes = [
-      {
-        version: '10.0',
-        device: 'iPhone 6s'
-      }
-    ];
-  }
+  let version = (process.env.DEVICE === '10' || process.env.DEVICE === '10.0') ? '10.0' : process.env.DEVICE;
+  deviceTypes = [
+    {
+      version,
+      device: 'iPhone 6s'
+    }
+  ];
 }
 
 for (let deviceType of deviceTypes) {

--- a/test/unit/certificate-specs.js
+++ b/test/unit/certificate-specs.js
@@ -22,39 +22,36 @@ let tempDirectory;
 
 describe('when using TrustStore class', () => {
 
+  function getUUID () {
+    return uuid.v4().replace(/\-/g, '');
+  }
+
   beforeEach(async () => {
     keychainsDirOriginal = `${assetsDir}/Library/Keychains-Original`;
     await fs.rimraf(keychainsDir);
     copySync(keychainsDirOriginal, keychainsDir);
     trustStore = new TrustStore(assetsDir);
-    testUUID = uuid.v4();
+    testUUID = getUUID();
   });
 
   it('can add a record to the TrustStore tsettings', async () => {
-    let tsettings = await trustStore.getRecords(testUUID);
-    expect(tsettings).to.have.length.of(0);
-    await trustStore.addRecord(uuid.v4(), 'tset', testUUID, 'data');
-    tsettings = await trustStore.getRecords(testUUID);
-    expect(tsettings).to.have.length.above(0);
-    tsettings[0].subj.should.equal(testUUID);
+    expect(await trustStore.hasRecords(testUUID)).to.be.false;
+    await trustStore.addRecord(getUUID(), 'tset', testUUID, '0123');
+    expect(await trustStore.hasRecords(testUUID)).to.be.true;
   });
 
   it('can add and remove records to in TrustStore tsettings', async () => {
-    await trustStore.addRecord(uuid.v4(), 'tset', testUUID, 'data');
-    let tsettings = await trustStore.getRecords(testUUID);
-    expect(tsettings).to.have.length.above(0);
+    await trustStore.addRecord(getUUID(), 'tset', testUUID, '0123');
+    expect(await trustStore.hasRecords(testUUID)).to.be.true;
     await trustStore.removeRecord(testUUID);
-    tsettings = await trustStore.getRecords(testUUID);
-    expect(tsettings).to.have.length(0);
+    expect(await trustStore.hasRecords(testUUID)).to.be.false;
   });
 
   it('can update a record in the TrustStore tsettings', async () => {
-    await trustStore.addRecord(uuid.v4(), 'tset', testUUID, 'data1');
-    let tsettings = await trustStore.getRecords(testUUID);
-    expect(tsettings[0].data).to.equal('data1');
-    await trustStore.addRecord(uuid.v4(), 'tset', testUUID, 'data2');
-    tsettings = await trustStore.getRecords(testUUID);
-    expect(tsettings[0].data).to.equal('data2');
+    await trustStore.addRecord(getUUID(), 'tset', testUUID, '0123');
+    await trustStore.addRecord(getUUID(), 'tset', testUUID, '4567');
+
+    expect(await trustStore.getRecordCount(testUUID)).to.equal(1);  
   });
 });
 
@@ -71,9 +68,8 @@ describe('when using TrustStore class when the keychains directory doesn\'t exis
 
   it('will create a new keychains directory with a SQLite DB', async () => {
     let newTrustStore = new TrustStore(tempDirectory);
-    await newTrustStore.addRecord('test', 'test', 'test', 'test');
-    let tsettings = await newTrustStore.getRecords('test');
-    expect(tsettings).to.have.length(1);
+    await newTrustStore.addRecord('0123', 'test', 'test', '0123');
+    expect(await newTrustStore.hasRecords('test')).to.be.true;
   });
 });
 


### PR DESCRIPTION
-Uses teen_process exec to run sqlite3 from command line (sqlite3 comes packaged with OSX)
-Inserts sha1 and data in the hex format because they're both BLOBs
-Added a 'hasRecords' and 'getRecordCount' function that checks how many records are in tsettings and then parses the result
-Checks that 'sqlite3' is available on path before installing an SSL cert (just in case it was uninstalled or unavailable in a future release)
-Updated tests to use new code

Reviewers @jlipps @imurchie 

