### PR TITLE
Optimize the way we detect Simulator is booted

### DIFF
--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -58,9 +58,14 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     const startupTimestamp = process.hrtime();
     try {
       await waitForCondition(async () => {
-        let {stdout} = await exec('bash', ['-c',
-          "ps axo command | grep Simulator | grep nsurlstoraged | grep -v bash | grep -v grep"]);
-        return stdout.trim().length > 0;
+        try {
+          let {stdout} = await exec('bash', ['-c',
+            "ps axo command | grep Simulator | grep nsurlstoraged | grep -v bash | grep -v grep"]);
+          return stdout.trim().length > 0;
+        } catch (e) {
+          // Continue iteration in case of error
+          return false;
+        }
       }, {waitMs: startupTimeout, intervalMs: 500});
     } catch (err) {
       log.errorAndThrow(`The Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds`);

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -75,8 +75,6 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     } catch (err) {
       log.errorAndThrow(`Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds`);
     }
-
-    log.debug(`Simulator is booted and running after ${process.hrtime(startupTimestamp)[0]} seconds`);
   }
 
 }

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -60,15 +60,19 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       await waitForCondition(async () => {
         try {
           let {stdout} = await exec('bash', ['-c',
-            "ps axo command | grep Simulator | grep nsurlstoraged | grep -v bash | grep -v grep"]);
-          return stdout.trim().length > 0;
+            'ps axo command | grep Simulator | grep nsurlstoraged | grep -v bash | grep -v grep']);
+          if (stdout.trim().length > 0) {
+            // 'springboard' process should be the last one to start after boot
+            // 'simctl launch' will block until this process is running
+            await exec('bash', ['-c', `xcrun simctl launch ${this.udid} com.apple.springboard`]);
+          }
         } catch (e) {
           // Continue iteration in case of error
           return false;
         }
       }, {waitMs: startupTimeout, intervalMs: 500});
     } catch (err) {
-      log.errorAndThrow(`The Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds`);
+      log.errorAndThrow(`Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds`);
     }
 
     log.debug(`Simulator is booted and running after ${process.hrtime(startupTimestamp)[0]} seconds`);

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -1,5 +1,7 @@
 import SimulatorXcode7 from './simulator-xcode-7';
 import log from './logger';
+import { waitForCondition } from 'asyncbox';
+import { exec } from 'teen_process';
 
 
 // these sims are sloooooooow
@@ -46,6 +48,25 @@ class SimulatorXcode8 extends SimulatorXcode7 {
         indicator = 'no boot indicator string available';
     }
     return indicator;
+  }
+
+  async waitForBoot (startupTimeout) {
+    // wait for the simulator to boot
+    // waiting for the simulator status to be 'booted' isn't good enough
+    // it claims to be booted way before finishing loading
+    // let's wait for the magic nsurlstoraged process, which signals the booting has been completed
+    const startupTimestamp = process.hrtime();
+    try {
+      await waitForCondition(async () => {
+        let {stdout} = await exec('bash', ['-c',
+          "ps axo command | grep Simulator | grep nsurlstoraged | grep -v bash | grep -v grep"]);
+        return stdout.trim().length > 0;
+      }, {waitMs: startupTimeout, intervalMs: 500});
+    } catch (err) {
+      log.errorAndThrow(`The Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds`);
+    }
+
+    log.debug(`Simulator is booted and running after ${process.hrtime(startupTimestamp)[0]} seconds`);
   }
 
 }

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -20,34 +20,10 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       'Library/Preferences/com.apple.springboard.plist',
       'var/run/syslog.pid'
     ];
-
-    this.extraStartupTime = 10000;
   }
 
   get startupTimeout () {
     return STARTUP_TIMEOUT;
-  }
-
-  async getBootedIndicatorString () {
-    let indicator;
-    let platformVersion = await this.getPlatformVersion();
-    switch (platformVersion) {
-      case '9.0':
-      case '9.1':
-      case '9.2':
-      case '9.3':
-        indicator = 'System app "com.apple.springboard" finished startup';
-        break;
-      case '10.0':
-      case '10.1':
-      case '10.2':
-        indicator = 'SMS Plugin initialized';
-        break;
-      default:
-        log.warn(`No boot indicator case for platform version '${platformVersion}'`);
-        indicator = 'no boot indicator string available';
-    }
-    return indicator;
   }
 
   async waitForBoot (startupTimeout) {

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -65,11 +65,12 @@ class SimulatorXcode8 extends SimulatorXcode7 {
             // 'springboard' process should be the last one to start after boot
             // 'simctl launch' will block until this process is running
             await exec('bash', ['-c', `xcrun simctl launch ${this.udid} com.apple.springboard`]);
+            return true;
           }
         } catch (e) {
           // Continue iteration in case of error
-          return false;
         }
+        return false;
       }, {waitMs: startupTimeout, intervalMs: 500});
     } catch (err) {
       log.errorAndThrow(`Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds`);


### PR DESCRIPTION
Use process detection instead of looking for magic string in logs. This should make the detection more stable and shorten simulator startup duration.