### PR TITLE
Make it possible to add onBootCompleted callback to Simulator

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -47,6 +47,21 @@ class SimulatorXcode6 {
 
     // extra time to wait for simulator to be deemed booted
     this.extraStartupTime = EXTRA_STARTUP_TIME;
+
+    this.onBootCompetedCallback = null;
+  }
+
+  /*
+  * Sets the callback, which is invoked as soon as iOS Simulator
+  * has finished booting and it is ready to accept xcrun commands.
+  * The callback function is called as soon as 'start' method is completed
+  * for Xcode 7 and older and is only useful in Xcode 8+
+  * since one can start doing stuff (for example install/uninstall an app) in parallel
+  * with Simulator UI startup, which shortens session startup time.
+  * @param callback Async function without arguments
+  */
+  setOnBootCompleted (callback) {
+    this.onBootCompetedCallback = callback;
   }
 
   get startupTimeout () {
@@ -224,6 +239,8 @@ class SimulatorXcode6 {
     log.debug(`Waiting an extra ${this.extraStartupTime}ms for the simulator to really finish booting`);
     await B.delay(this.extraStartupTime);
     log.debug('Done waiting extra time for simulator');
+
+    this.onBootCompetedCallback();
   }
 
   async getBootedIndicatorString () {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -240,7 +240,9 @@ class SimulatorXcode6 {
     await B.delay(this.extraStartupTime);
     log.debug('Done waiting extra time for simulator');
 
-    this.onBootCompetedCallback();
+    if (this.onBootCompetedCallback !== null) {
+      this.onBootCompetedCallback();
+    }
   }
 
   async getBootedIndicatorString () {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -20,7 +20,7 @@ const EXTRA_STARTUP_TIME = 2000;
 /*
  * This event is emitted as soon as iOS Simulator
  * has finished booting and it is ready to accept xcrun commands.
- * The event handler is called after 'waitForBoot' method is completed
+ * The event handler is called after 'run' method is completed
  * for Xcode 7 and older and is only useful in Xcode 8+,
  * since one can start doing stuff (for example install/uninstall an app) in parallel
  * with Simulator UI startup, which shortens session startup time.
@@ -235,8 +235,6 @@ class SimulatorXcode6 extends EventEmitter {
     log.debug(`Waiting an extra ${this.extraStartupTime}ms for the simulator to really finish booting`);
     await B.delay(this.extraStartupTime);
     log.debug('Done waiting extra time for simulator');
-
-    this.emit(ON_BOOT_COMPLETED_EVENT);
   }
 
   async getBootedIndicatorString () {
@@ -282,6 +280,7 @@ class SimulatorXcode6 extends EventEmitter {
     await this.waitForBoot(startupTimeout);
 
     log.info(`Simulator booted in ${Date.now() - startTime}ms`);
+    this.emit(ON_BOOT_COMPLETED_EVENT);
   }
 
   // TODO keep keychains

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -11,14 +11,25 @@ import * as settings from './settings';
 import { exec } from 'teen_process';
 import { tailUntil } from './tail-until.js';
 import extensions from './extensions/index';
-
+import events from 'events';
+const { EventEmitter } = events;
 
 const OPEN_TIMEOUT = 3000;
 const STARTUP_TIMEOUT = 60 * 1000;
 const EXTRA_STARTUP_TIME = 2000;
+/*
+ * This event is emitted as soon as iOS Simulator
+ * has finished booting and it is ready to accept xcrun commands.
+ * The event handler is called after 'waitForBoot' method is completed
+ * for Xcode 7 and older and is only useful in Xcode 8+,
+ * since one can start doing stuff (for example install/uninstall an app) in parallel
+ * with Simulator UI startup, which shortens session startup time.
+ */
+const ON_BOOT_COMPLETED_EVENT = 'onBootCompleted';
 
-class SimulatorXcode6 {
+class SimulatorXcode6 extends EventEmitter {
   constructor (udid, xcodeVersion) {
+    super();
     this.udid = String(udid);
     this.xcodeVersion = xcodeVersion;
 
@@ -47,21 +58,6 @@ class SimulatorXcode6 {
 
     // extra time to wait for simulator to be deemed booted
     this.extraStartupTime = EXTRA_STARTUP_TIME;
-
-    this.onBootCompetedCallback = null;
-  }
-
-  /*
-  * Sets the callback, which is invoked as soon as iOS Simulator
-  * has finished booting and it is ready to accept xcrun commands.
-  * The callback function is called as soon as 'start' method is completed
-  * for Xcode 7 and older and is only useful in Xcode 8+
-  * since one can start doing stuff (for example install/uninstall an app) in parallel
-  * with Simulator UI startup, which shortens session startup time.
-  * @param callback Async function without arguments
-  */
-  setOnBootCompleted (callback) {
-    this.onBootCompetedCallback = callback;
   }
 
   get startupTimeout () {
@@ -240,9 +236,7 @@ class SimulatorXcode6 {
     await B.delay(this.extraStartupTime);
     log.debug('Done waiting extra time for simulator');
 
-    if (this.onBootCompetedCallback !== null) {
-      this.onBootCompetedCallback();
-    }
+    this.emit(ON_BOOT_COMPLETED_EVENT);
   }
 
   async getBootedIndicatorString () {

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -39,7 +39,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
           let {stdout} = await exec('bash', ['-c',
             'ps axo command | grep Simulator | grep nsurlstoraged | grep -v bash | grep -v grep']);
           if (stdout.trim().length > 0) {
-            if (!isOnBootCallbackInvoked) {
+            if (!isOnBootCallbackInvoked && this.onBootCompetedCallback !== null) {
               isOnBootCallbackInvoked = true;
               this.onBootCompetedCallback();
             }

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -1,3 +1,4 @@
+import { ON_BOOT_COMPLETED_EVENT } from './simulator-xcode-6';
 import SimulatorXcode7 from './simulator-xcode-7';
 import log from './logger';
 import { waitForCondition } from 'asyncbox';
@@ -33,15 +34,15 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     // let's wait for the magic nsurlstoraged process, which signals the booting has been completed
     const startupTimestamp = process.hrtime();
     try {
+      let isOnBootCompletedEmitted = false;
       await waitForCondition(async () => {
-        let isOnBootCallbackInvoked = false;
         try {
           let {stdout} = await exec('bash', ['-c',
             'ps axo command | grep Simulator | grep nsurlstoraged | grep -v bash | grep -v grep']);
           if (stdout.trim().length > 0) {
-            if (!isOnBootCallbackInvoked && this.onBootCompetedCallback !== null) {
-              isOnBootCallbackInvoked = true;
-              this.onBootCompetedCallback();
+            if (!isOnBootCompletedEmitted) {
+              isOnBootCompletedEmitted = true;
+              this.emit(ON_BOOT_COMPLETED_EVENT);
             }
             // 'springboard' process should be the last one to start after boot
             // 'simctl launch' will block until this process is running

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -34,10 +34,15 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     const startupTimestamp = process.hrtime();
     try {
       await waitForCondition(async () => {
+        let isOnBootCallbackInvoked = false;
         try {
           let {stdout} = await exec('bash', ['-c',
             'ps axo command | grep Simulator | grep nsurlstoraged | grep -v bash | grep -v grep']);
           if (stdout.trim().length > 0) {
+            if (!isOnBootCallbackInvoked) {
+              isOnBootCallbackInvoked = true;
+              this.onBootCompetedCallback();
+            }
             // 'springboard' process should be the last one to start after boot
             // 'simctl launch' will block until this process is running
             await exec('bash', ['-c', `xcrun simctl launch ${this.udid} com.apple.springboard`]);


### PR DESCRIPTION
IOS simulator allows to execute some xcrun terminal commands even if UI initialisation has not been 100% completed. This will allow us to shorten session init duration if we install/uninstall app under test in parallel while Simulator is still booting.