### PR TITLE
Add killall signal in Sierra

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,12 +4,25 @@ import { exec } from 'teen_process';
 import { waitForCondition } from 'asyncbox';
 import { getVersion } from 'appium-xcode';
 import { getDevices } from 'node-simctl';
-import { fs } from 'appium-support';
+import { fs, system } from 'appium-support';
 import { Certificate } from './certificate';
 import path from 'path';
 import Simulator from './simulator-xcode-6';
 
+
 const OSASCRIPT_TIMEOUT = 10000;
+
+async function sendKillAll (appName) {
+  try {
+    await exec('killall', [appName]);
+  } catch (err) {
+    // if no process exists we'll get an error that we expect.
+    // otherwise throw it again
+    if (err.stderr.indexOf(`No matching processes belonging to you were found`) === -1) {
+      throw err;
+    }
+  }
+}
 
 async function killAllSimulators (timeout = OSASCRIPT_TIMEOUT) {
   log.debug('Killing all iOS Simulators');
@@ -24,17 +37,21 @@ async function killAllSimulators (timeout = OSASCRIPT_TIMEOUT) {
 
   try {
     await exec('osascript', ['-e', `quit app "${appName}"`], {timeout});
+
+    // in Sierra the killing with AppleScript often pretends to work but fails
+    let macVersion = await system.macOsxVersion();
+    if (macVersion === '10.12') {
+      await sendKillAll(appName);
+    }
   } catch (e) {
     let errString = JSON.stringify(e);
     if (errString.match(/Application isn.t running/)) {
       // on some systems we get an error that the application is not running
       log.debug('Application is not running. Continuing');
-    } else if (e.message.match(/timed out/)) {
-      // sometimes, especially in xcode 8, the sim hangs
-      log.debug('Killing simulator timed out. Using killall signal');
-      await exec('killall', [appName]);
     } else {
-      log.errorAndThrow(e);
+      // sometimes, especially in xcode 8, the sim hangs
+      log.debug('Killing simulator failed. Using killall signal');
+      await sendKillAll(appName);
     }
   }
 
@@ -51,8 +68,7 @@ async function killAllSimulators (timeout = OSASCRIPT_TIMEOUT) {
                  state === 'unavailable' ||
                  state === 'disconnected';
       if (!done) {
-        remainingDevices.push(`Simulator not shut down: ${sim.name} (${sim.sdk}, udid: ` +
-                              `${sim.udid}) is still in state '${state}'`);
+        remainingDevices.push(`${sim.name} (${sim.sdk}, udid: ${sim.udid}) is still in state '${state}'`);
       }
       return done;
     });
@@ -64,9 +80,9 @@ async function killAllSimulators (timeout = OSASCRIPT_TIMEOUT) {
     });
   } catch (err) {
     if (remainingDevices && remainingDevices.length !== 0) {
-      log.error('The following devices are not in the correct state:');
+      log.warn('The following devices are not in the correct state:');
       for (let device of remainingDevices) {
-        log.error(`    ${device}`);
+        log.warn(`    ${device}`);
       }
     }
     throw err;


### PR DESCRIPTION
On 10.12 the killing of sims is often flakey. sending the killall command is much more reliable.