### PR TITLE
Add simulator argument to disconnect hardware keyboard by default

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -268,7 +268,7 @@ class SimulatorXcode6 extends EventEmitter {
 
   async run (startupTimeout = this.startupTimeout) {
     let simulatorApp = path.resolve(await getXcodePath(), 'Applications', this.simulatorApp);
-    let args = ['-Fn', simulatorApp, '--args', '-CurrentDeviceUDID', this.udid];
+    let args = ['-Fn', simulatorApp, '--args', '-ConnectHardwareKeyboard', '0', '-CurrentDeviceUDID', this.udid];
     if (this.scaleFactor) {
       let stat = await this.stat();
       let formattedDeviceName = stat.name.replace(/\s+/g, '-');


### PR DESCRIPTION
This helps to workaround known XCTest issue described in https://github.com/facebook/WebDriverAgent/issues/453

I think it's safe to have this option included by default, since it does not affect anything while interacting with the Simulator via Appium. Although, we could also add a separate capability to have it enabled or disabled, if you think this can be somehow useful.