### PR TITLE
Do not try to start the simulator if there are no folders

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -100,16 +100,10 @@ class SimulatorXcode6 extends EventEmitter {
    * or, for iOS 7.1, the app name without `.app` (e.g., MobileSafari)
    */
   async getAppDir (id, subDir = 'Data') {
-    if (await this.isFresh()) {
-      log.info('Attempted to get an app path from a fresh simulator ' +
-               'quickly launching the sim to populate its directories');
-      await this.launchAndQuit();
-    }
-
-    if (!this.appDataBundlePaths[subDir]) {
+    this.appDataBundlePaths[subDir] = this.appDataBundlePaths[subDir] || {};
+    if (_.isEmpty(this.appDataBundlePaths[subDir]) && !await this.isFresh()) {
       this.appDataBundlePaths[subDir] = await this.buildBundlePathMap(subDir);
     }
-
     return this.appDataBundlePaths[subDir][id];
   }
 
@@ -309,7 +303,7 @@ class SimulatorXcode6 extends EventEmitter {
     // get the directories to be deleted
     let appDirs = await this.getAppDirs(appFile, appBundleId, scrub);
 
-    if (appDirs.length === 0) {
+    if (appDirs && appDirs.length === 0) {
       log.debug("Could not find app directories to delete. It is probably not installed");
       return;
     }
@@ -457,6 +451,7 @@ class SimulatorXcode6 extends EventEmitter {
 
     let deletePromises = [];
     for (let dir of dirs) {
+      if (!dir) continue;
       log.debug(`Deleting directory: '${dir}'`);
       deletePromises.push(fs.rimraf(dir));
     }
@@ -472,7 +467,13 @@ class SimulatorXcode6 extends EventEmitter {
     }
 
     let libraryDir = path.resolve(this.getDir(), 'Library');
-    let safariLibraryDir = path.resolve(await this.getAppDir('com.apple.mobilesafari'), 'Library');
+    let safariRoot = await this.getAppDir('com.apple.mobilesafari');
+    if (!safariRoot) {
+      log.info('Could not find Safari support directories to clean out old ' +
+               'data. Probably there is nothing to clean out');
+      return;
+    }
+    let safariLibraryDir = path.resolve(safariRoot, 'Library');
     let filesToDelete = [
       'Caches/Snapshots/com.apple.mobilesafari',
       'Caches/com.apple.mobilesafari/Cache.db*',

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -331,6 +331,7 @@ class SimulatorXcode6 extends EventEmitter {
     // iOS 7.1 has only one directory
     if (await this.getPlatformVersion() >= 8) {
       let data = await this.getAppDir(appBundleId);
+      if (!data) return dirs;
 
       // the `Bundle` directory has the actual app in it. If we are just scrubbing,
       // we want this to stay. If we are cleaning we delete
@@ -450,8 +451,7 @@ class SimulatorXcode6 extends EventEmitter {
     }
 
     let deletePromises = [];
-    for (let dir of dirs) {
-      if (!dir) continue;
+    for (let dir of _.compact(dirs)) {
       log.debug(`Deleting directory: '${dir}'`);
       deletePromises.push(fs.rimraf(dir));
     }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -303,7 +303,7 @@ class SimulatorXcode6 extends EventEmitter {
     // get the directories to be deleted
     let appDirs = await this.getAppDirs(appFile, appBundleId, scrub);
 
-    if (appDirs && appDirs.length === 0) {
+    if (appDirs.length === 0) {
       log.debug("Could not find app directories to delete. It is probably not installed");
       return;
     }

--- a/test/simulator-e2e-specs.js
+++ b/test/simulator-e2e-specs.js
@@ -171,16 +171,16 @@ function runTests (deviceType) {
       await fs.hasAccess(path).should.eventually.be.true;
     });
 
-    itText = 'should match a bundleId to its app directory on a fresh sim';
+    itText = 'should not match a bundleId to its app directory on a fresh sim';
     bundleId = 'com.apple.mobilesafari';
     if (deviceType.version === '7.1') {
-      itText = 'should match an app to its app directory on a fresh sim';
+      itText = 'should not match an app to its app directory on a fresh sim';
       bundleId = 'MobileSafari';
     }
     it(itText, async function () {
       let sim = await getSimulator(udid);
       let path = await sim.getAppDir(bundleId);
-      await fs.hasAccess(path).should.eventually.be.true;
+      chai.should().equal(path, undefined);
     });
 
     it('should start a sim using the "run" method', async function () {


### PR DESCRIPTION
I suppose there is no need to start and stop Simulator if there is no directory for the given app. Returning **undefined** means the app has no data to cleanup, which is OK for us. And starting the simulator and then quitting it is a very time-expensive operation.