### PR TITLE
Move to logger from appium-support

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,5 @@
-import { getLogger } from 'appium-logger';
+import { logger } from 'appium-support';
 
-const log = getLogger('iOSSim');
+const log = logger.getLogger('iOSSim');
 
 export default log;

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "appium-logger": "^2.1.0",
-    "appium-support": "^2.0.10",
+    "appium-support": "^2.4.0",
     "appium-xcode": "^3.1.0",
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",


### PR DESCRIPTION
Stop using the deprecated `appium-logger`.