### PR TITLE
Added enrollTouchID() method to Simulator

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -5,7 +5,8 @@ import log from './logger';
 import { fs } from 'appium-support';
 import B from 'bluebird';
 import _ from 'lodash';
-import { killAllSimulators, safeRimRaf, bindTouchIDKey } from './utils.js';
+import { killAllSimulators, safeRimRaf } from './utils.js';
+import { setTouchEnrollKey } from './touch-enroll.js';
 import { asyncmap, waitForCondition, retryInterval, retry } from 'asyncbox';
 import * as settings from './settings';
 import { exec } from 'teen_process';
@@ -290,7 +291,10 @@ class SimulatorXcode6 extends EventEmitter {
     if (!this.connectHardwareKeyboard) {
       args.push('-ConnectHardwareKeyboard', '0');
     }
-    await bindTouchIDKey();
+
+    // Do the 'Touch ID Enroll' key bindings before the Simulator starts
+    await setTouchEnrollKey();
+
     log.info(`Starting simulator with command: open ${args.join(' ')}`);
     let startTime = Date.now();
     await exec('open', args, {timeout: OPEN_TIMEOUT});

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -5,7 +5,7 @@ import log from './logger';
 import { fs } from 'appium-support';
 import B from 'bluebird';
 import _ from 'lodash';
-import { killAllSimulators, safeRimRaf } from './utils.js';
+import { killAllSimulators, safeRimRaf, bindTouchIDKey } from './utils.js';
 import { asyncmap, waitForCondition, retryInterval, retry } from 'asyncbox';
 import * as settings from './settings';
 import { exec } from 'teen_process';
@@ -290,6 +290,7 @@ class SimulatorXcode6 extends EventEmitter {
     if (!this.connectHardwareKeyboard) {
       args.push('-ConnectHardwareKeyboard', '0');
     }
+    await bindTouchIDKey();
     log.info(`Starting simulator with command: open ${args.join(' ')}`);
     let startTime = Date.now();
     await exec('open', args, {timeout: OPEN_TIMEOUT});
@@ -592,6 +593,15 @@ class SimulatorXcode6 extends EventEmitter {
 
   async hasCalendarAccess (bundleID) {
     return await this.calendar.hasCalendarAccess(bundleID);
+  }
+
+  async enrollTouchID () {
+    await exec('osascript', ['-e', `
+      activate application "Simulator"
+      tell application "System Events"
+        key code 17 using {control down, shift down, option down, command down}
+      end tell
+    `]);
   }
 
   static async _getDeviceStringPlatformVersion (platformVersion) {

--- a/lib/touch-enroll.js
+++ b/lib/touch-enroll.js
@@ -1,8 +1,4 @@
-import { exec as nodeExec } from 'child_process';
-import B from 'bluebird';
-
-// Had problems with teen_process, resorted to this
-const exec = B.promisify(nodeExec);
+import { exec } from 'teen_process';
 
 let touchEnrollMenuKeys = ['Toggle Enrolled State', 'Touch ID Enrolled'];
 let touchEnrollBackups;
@@ -39,11 +35,11 @@ async function getUserDefault (domain, key) {
   let res;
   try {
     // If it doesn't find anything for this domain, it will throw an error so return undefined
-    res = await exec(`"defaults" read "Apple Global Domain" ${domain}`);
+    res = await exec('defaults', ['read', 'Apple Global Domain', domain]);
   } catch (stderr) {
     return;
   }
-  let stdout = res[0];
+  let stdout = res.stdout;
 
   // Parse the result into a Javascript array
   let nsUserKeyArr = stdout.trim()
@@ -74,8 +70,7 @@ async function getUserDefault (domain, key) {
  * @param {*} value 
  */
 async function setUserDefault (domain, key, value) {
-  let quotedValue = `'${value}'`;
-  await exec(`defaults write "Apple Global Domain" ${domain} -dict-add "${key}" ${typeof(value) === 'undefined' ? 'nil' : quotedValue}`);
+  await exec('defaults', ['write', 'Apple Global Domain', domain, '-dict-add', key, typeof(value) === 'undefined' ? 'nil' : value]);
 }
 
 async function backupTouchEnrollShortcuts () {

--- a/lib/touch-enroll.js
+++ b/lib/touch-enroll.js
@@ -1,0 +1,95 @@
+import { exec as nodeExec } from 'child_process';
+import B from 'bluebird';
+
+// Had problems with teen_process, resorted to this
+const exec = B.promisify(nodeExec);
+
+let touchEnrollMenuKeys = ['Toggle Enrolled State', 'Touch ID Enrolled'];
+let touchEnrollBackups;
+const NS_USER_KEY_EQUIVALENTS = 'NSUserKeyEquivalents';
+const TOUCH_ENROLL_KEY_CODE = '@~$^t';
+
+async function setTouchEnrollKey () {
+  await backupTouchEnrollShortcuts();
+  for (let key of touchEnrollMenuKeys) {
+    await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, TOUCH_ENROLL_KEY_CODE);
+  }
+}
+
+async function setTouchEnrollKeys (pairs) {
+  for (let [key, value] of pairs) {
+    await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, value);
+  }
+}
+
+async function getTouchEnrollKeys () {
+  let backups = [];
+  for (let key of touchEnrollMenuKeys) {
+    backups.push([key, await getUserDefault(NS_USER_KEY_EQUIVALENTS, key)]);
+  }
+  return backups;
+}
+
+/**
+ * Get MacOS User Defaults by domain and key (for reference: `man defaults`)
+ * @param {*} domain {string}
+ * @param {*} key {string|number|boolean}
+ */
+async function getUserDefault (domain, key) {
+  let res;
+  try {
+    // If it doesn't find anything for this domain, it will throw an error so return undefined
+    res = await exec(`"defaults" read "Apple Global Domain" ${domain}`);
+  } catch (stderr) {
+    return;
+  }
+  let stdout = res[0];
+
+  // Parse the result into a Javascript array
+  let nsUserKeyArr = stdout.trim()
+    .replace(/^{/, '') // Remove leading {
+    .replace(/}$/, '') // Remove trailing }
+    .trim()
+    .replace(/;$/, '') // Remove trailing semicolon
+    .split(';') // Break up expressions by semicolon
+    .map((expr) => {
+      let [key, value] = expr.split('=');
+      key = key.trim().replace(/^"/, '').replace(/"$/, '');
+      value = value.trim().replace(/^"/, '').replace(/"$/, '');
+      return [key, value];
+    });
+
+  
+  for (let [testKey, value] of nsUserKeyArr) {
+    if (testKey === key) {
+      return value.replace(/\\\\/g, '\\');
+    }
+  }
+}
+
+/**
+ * Sets a MacOS User Default value on a domain
+ * @param {*} domain 
+ * @param {*} key 
+ * @param {*} value 
+ */
+async function setUserDefault (domain, key, value) {
+  let quotedValue = `'${value}'`;
+  await exec(`defaults write "Apple Global Domain" ${domain} -dict-add "${key}" ${typeof(value) === 'undefined' ? 'nil' : quotedValue}`);
+}
+
+async function backupTouchEnrollShortcuts () {
+  if (!touchEnrollBackups) {
+    touchEnrollBackups = await getTouchEnrollKeys();
+  }
+}
+
+async function restoreTouchEnrollShortcuts () {
+  if (touchEnrollBackups) {
+    await setTouchEnrollKeys(touchEnrollBackups);
+    touchEnrollBackups = undefined;
+  }
+}
+
+export { setTouchEnrollKey, getTouchEnrollKeys, setTouchEnrollKeys, getUserDefault, setUserDefault, touchEnrollMenuKeys, backupTouchEnrollShortcuts, restoreTouchEnrollShortcuts, 
+  NS_USER_KEY_EQUIVALENTS, TOUCH_ENROLL_KEY_CODE};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ import { getVersion } from 'appium-xcode';
 import { getDevices } from 'node-simctl';
 import { fs } from 'appium-support';
 import { Certificate } from './certificate';
+import { restoreTouchEnrollShortcuts } from './touch-enroll';
 import path from 'path';
 import Simulator from './simulator-xcode-6';
 import fkill from 'fkill';
@@ -38,7 +39,9 @@ async function killAllSimulators (timeout = DEFAULT_SIM_SHUTDOWN_TIMEOUT) {
   log.debug('Killing all iOS Simulators');
   const xcodeVersion = await getVersion(true);
   const appName = xcodeVersion.major >= 7 ? 'Simulator' : 'iOS Simulator';
-  await bindTouchIDKey(false); // Remove touchID binding
+
+  // Restore default shortcut key to original state
+  await restoreTouchEnrollShortcuts();
 
   let pids;
   try {
@@ -223,11 +226,4 @@ async function execSQLiteQuery (db, query, ...queryParams) {
   return await exec('sqlite3', ['-line', db, formattedQuery.join('')]);
 }
 
-async function bindTouchIDKey (bind = true) {
-  // JSHint ignore is to ignore the bad/unnecessary escaping rule
-  ['Toggle Enrolled State', 'Touch ID Enrolled'].forEach(async (key) => 
-    await exec('defaults', ['write', '"Apple Global Domain"', 'NSUserKeyEquivalents', '-dict-add', `"${key}"`, bind ? '"@~\\$^t"': 'nil'])
-  );
-}
-
-export { killAllSimulators, endAllSimulatorDaemons, safeRimRaf, simExists, installSSLCert, uninstallSSLCert, execSQLiteQuery, bindTouchIDKey };
+export { killAllSimulators, endAllSimulatorDaemons, safeRimRaf, simExists, installSSLCert, uninstallSSLCert, execSQLiteQuery };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,9 +36,9 @@ async function pkill (appName, forceKill = false) {
 
 async function killAllSimulators (timeout = DEFAULT_SIM_SHUTDOWN_TIMEOUT) {
   log.debug('Killing all iOS Simulators');
-
   const xcodeVersion = await getVersion(true);
   const appName = xcodeVersion.major >= 7 ? 'Simulator' : 'iOS Simulator';
+  await bindTouchIDKey(false); // Remove touchID binding
 
   let pids;
   try {
@@ -223,4 +223,11 @@ async function execSQLiteQuery (db, query, ...queryParams) {
   return await exec('sqlite3', ['-line', db, formattedQuery.join('')]);
 }
 
-export { killAllSimulators, endAllSimulatorDaemons, safeRimRaf, simExists, installSSLCert, uninstallSSLCert, execSQLiteQuery };
+async function bindTouchIDKey (bind = true) {
+  // JSHint ignore is to ignore the bad/unnecessary escaping rule
+  ['Toggle Enrolled State', 'Touch ID Enrolled'].forEach(async (key) => 
+    await exec('defaults', ['write', '"Apple Global Domain"', 'NSUserKeyEquivalents', '-dict-add', `"${key}"`, bind ? '"@~\\$^t"': 'nil'])
+  );
+}
+
+export { killAllSimulators, endAllSimulatorDaemons, safeRimRaf, simExists, installSSLCert, uninstallSSLCert, execSQLiteQuery, bindTouchIDKey };

--- a/test/functional/touch-enroll-e2e-specs.js
+++ b/test/functional/touch-enroll-e2e-specs.js
@@ -1,0 +1,163 @@
+// transpile:mocha
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { exec } from 'teen_process';
+import { getUserDefault, setUserDefault, setTouchEnrollKey, setTouchEnrollKeys, getTouchEnrollKeys, touchEnrollMenuKeys, 
+  restoreTouchEnrollShortcuts, NS_USER_KEY_EQUIVALENTS, TOUCH_ENROLL_KEY_CODE } from '../../lib/touch-enroll';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('touch-enroll.js', () => {
+
+  describe('getUserDefaults(), setUserDefaults()', () => {
+    let domain = 'fakeDomain';
+
+  // Nuke the contents of the domain so it's fresh every test case
+    let clearFakeDomain = async function () {
+      try {
+        await exec('defaults', ['delete', 'Apple Global Domain', domain]);
+      } catch (ign) { }
+    };
+
+    beforeEach(async () => {
+      await clearFakeDomain();
+    });
+
+    afterEach(async () => {
+      await clearFakeDomain();
+    });
+
+    it('should get undefined for non-existent keys', async () => {
+      await getUserDefault(domain, 'hello').should.eventually.be.undefined;
+      await getUserDefault(domain, 'foo').should.eventually.be.undefined;
+    });
+
+    it('should set defaults', async () => {
+      await setUserDefault(domain, 'hello', 'world');
+      await getUserDefault(domain, 'hello').should.eventually.equal('world');
+    });
+
+    it('should restore default to original value', async () => {
+      await setUserDefault(domain, 'hello', '1');
+      let originalValue = await getUserDefault(domain, 'hello');
+      originalValue.should.equal('1');
+      await setUserDefault(domain, 'hello', '2');
+      await getUserDefault(domain, 'hello').should.eventually.equal('2');
+      await setUserDefault(domain, 'hello', originalValue);
+      await getUserDefault(domain, 'hello').should.eventually.equal(originalValue);
+    });
+
+    it('should set multiple keys', async () => {
+      await setUserDefault(domain, 'hello', 'world');
+      await getUserDefault(domain, 'hello').should.eventually.equal('world');
+      await setUserDefault(domain, 'foo', 'bar');
+      await getUserDefault(domain, 'hello').should.eventually.equal('world');
+      await getUserDefault(domain, 'foo').should.eventually.equal('bar');
+      await setUserDefault(domain, 'hello', 'whirl');
+      await getUserDefault(domain, 'hello').should.eventually.equal('whirl');
+      await getUserDefault(domain, 'foo').should.eventually.equal('bar');
+    });
+
+    it('should set no value to nil', async () => {
+      await setUserDefault(domain, 'hello');
+      await getUserDefault(domain, 'hello').should.eventually.equal('nil');
+    });
+
+    it('should handle special characters', async () => {
+      await setUserDefault(domain, 'hello', TOUCH_ENROLL_KEY_CODE);
+      let firstRes = await getUserDefault(domain, 'hello').should.eventually.equal(TOUCH_ENROLL_KEY_CODE);
+      await setUserDefault(domain, 'hello', firstRes);
+      await getUserDefault(domain, 'hello').should.eventually.equal(firstRes);
+
+
+      await setUserDefault(domain, 'hello', '\\a');
+      firstRes = await getUserDefault(domain, 'hello').should.eventually.equal('\\a');
+      await setUserDefault(domain, 'hello', firstRes);
+      await getUserDefault(domain, 'hello').should.eventually.equal(firstRes);
+    });
+  });
+
+  describe('setTouchEnrollKeys, getTouchEnrollKeys, setTouchEnrollKeys', () => {
+    beforeEach(async () => {
+      for (let key of touchEnrollMenuKeys) {
+        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, undefined);
+      }
+    });
+
+    it('should set the touch enroll keys', async () => {
+      await setTouchEnrollKey();
+      for (let key of touchEnrollMenuKeys) {
+        await getUserDefault(NS_USER_KEY_EQUIVALENTS, key).should.eventually.equal(TOUCH_ENROLL_KEY_CODE);
+      }
+    });
+
+    it('should save touch enroll keys', async () => {
+      let index = 0;
+      for (let key of touchEnrollMenuKeys) {
+        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, index++);
+      }
+      let keys = await getTouchEnrollKeys();
+      keys[0][1].should.equal('0');
+      keys[1][1].should.equal('1');
+    });
+
+    it('should restore touch enroll keys to their original values', async () => {
+      // Set the keys to 0 and 1 and then back them up
+      let index = 0;
+      for (let key of touchEnrollMenuKeys) {
+        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, index++);
+      } 
+      let backedUpKeys = await getTouchEnrollKeys();
+      backedUpKeys[0][1].should.equal('0');
+      backedUpKeys[1][1].should.equal('1');
+
+      // Set the keys to touch enroll shortcuts
+      await setTouchEnrollKey();
+      let keys = await getTouchEnrollKeys();
+      keys[0][1].should.equal(TOUCH_ENROLL_KEY_CODE);
+      keys[1][1].should.equal(TOUCH_ENROLL_KEY_CODE);
+
+      // Restore the keys and check that they are the same
+      await setTouchEnrollKeys(backedUpKeys);
+      let restoredKeys = await getTouchEnrollKeys();
+      restoredKeys[0][1].should.equal('0');
+      restoredKeys[1][1].should.equal('1');
+    });
+  });
+  
+  describe('backup and restore defaults', async () => {
+
+    beforeEach(async () => {
+      // Set the shortcuts to nothing
+      for (let key of touchEnrollMenuKeys) {
+        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key);
+      }
+    });
+
+    it('should restore defaults after calling setTouchEnrollKey and then calling restore', async () => {
+      let originalValues = await getTouchEnrollKeys();
+      await setTouchEnrollKey();
+      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
+      await restoreTouchEnrollShortcuts();
+      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
+    });
+
+    it('should not do anything if restoring without backing up in the first place', async () => {
+      let originalValues = await getTouchEnrollKeys();
+      await restoreTouchEnrollShortcuts();
+      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
+    });
+
+    it('should restore to defaults even if we set touch enroll keys more than once', async () => {
+      let originalValues = await getTouchEnrollKeys();
+      await setTouchEnrollKey();
+      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
+      await setTouchEnrollKey();
+      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
+      await restoreTouchEnrollShortcuts();
+      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
+    });
+  });
+});

--- a/test/simulator-e2e-specs.js
+++ b/test/simulator-e2e-specs.js
@@ -9,7 +9,7 @@ import B from 'bluebird';
 import { absolute as testAppPath } from 'ios-test-app';
 import { retryInterval } from 'asyncbox';
 import path from 'path';
-
+import { setUserDefault, getTouchEnrollKeys, touchEnrollMenuKeys, NS_USER_KEY_EQUIVALENTS } from '../lib/touch-enroll';
 
 const LONG_TIMEOUT = 480 * 1000;
 const BUNDLE_ID = 'io.appium.TestApp';
@@ -298,19 +298,26 @@ function runTests (deviceType) {
     });
   });
 
-  describe('enrollTouchID()', async function () {
-    let sim, udid;
+  describe('touch ID enrollment', async function () {
+    let sim, udid, originalValues;
     this.timeout(LONG_TIMEOUT);
 
-    beforeEach(async function () {
+    it('should not reject calls to enrollTouchID() and should correctly restore backed up values', async function () {
+      // Set the touch enroll menu keys to NIL
+      for (let key of touchEnrollMenuKeys) {
+        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key);
+      }
+      originalValues = await getTouchEnrollKeys();
       udid = await simctl.createDevice('ios-simulator testing',
                                        deviceType.device,
                                        deviceType.version);
       sim = await getSimulator(udid);
-      await sim.run(LONG_TIMEOUT);
-    });
 
-    afterEach(async function () {
+      await sim.run(LONG_TIMEOUT);
+
+      await sim.enrollTouchID().should.eventually.be.resolved;
+      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
+
       // only want to get rid of the device if it is present
       await sim.shutdown();
       let devicePresent = (await simctl.getDevices())[deviceType.version]
@@ -320,10 +327,9 @@ function runTests (deviceType) {
       if (devicePresent) {
         await simctl.deleteDevice(sim.udid);
       }
-    });
 
-    it('should not reject calls to enrollTouchID()', async function () {
-      await sim.enrollTouchID().should.eventually.be.resolved;
+      // Check that the touchEnrollKeys where correctly restored
+      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
     });
   });
 }

--- a/test/simulator-e2e-specs.js
+++ b/test/simulator-e2e-specs.js
@@ -297,6 +297,35 @@ function runTests (deviceType) {
       stat.state.should.equal('Shutdown');
     });
   });
+
+  describe('enrollTouchID()', async function () {
+    let sim, udid;
+    this.timeout(LONG_TIMEOUT);
+
+    beforeEach(async function () {
+      udid = await simctl.createDevice('ios-simulator testing',
+                                       deviceType.device,
+                                       deviceType.version);
+      sim = await getSimulator(udid);
+      await sim.run(LONG_TIMEOUT);
+    });
+
+    afterEach(async function () {
+      // only want to get rid of the device if it is present
+      await sim.shutdown();
+      let devicePresent = (await simctl.getDevices())[deviceType.version]
+        .filter((device) => {
+          return device.udid === sim.udid;
+        }).length > 0;
+      if (devicePresent) {
+        await simctl.deleteDevice(sim.udid);
+      }
+    });
+
+    it('should not reject calls to enrollTouchID()', async function () {
+      await sim.enrollTouchID().should.eventually.be.resolved;
+    });
+  });
 }
 
 

--- a/test/unit/touch-enroll-specs.js
+++ b/test/unit/touch-enroll-specs.js
@@ -2,168 +2,65 @@
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { exec as execNode } from 'child_process';
-import B from 'bluebird';
-import { getUserDefault, setUserDefault, setTouchEnrollKey, setTouchEnrollKeys, getTouchEnrollKeys, touchEnrollMenuKeys, 
-  restoreTouchEnrollShortcuts, NS_USER_KEY_EQUIVALENTS, TOUCH_ENROLL_KEY_CODE } from '../../lib/touch-enroll';
-
-const exec = B.promisify(execNode);
+// import { exec } from 'teen_process';
+// import B from 'bluebird';  
+import * as TouchEnroll from '../../lib/touch-enroll';
+import * as TeenProcess from 'teen_process';
+import sinon from 'sinon';
 
 chai.should();
 chai.use(chaiAsPromised);
 
 describe('touch-enroll.js', () => {
 
-  describe('getUserDefaults(), setUserDefaults()', () => {
-    let domain = 'fakeDomain';
+  describe('getUserDefault()', () => {
+    let execStub;
 
-  // Nuke the contents of the domain so it's fresh every test case
-    let clearFakeDomain = async function () {
-      try {
-        await exec(`"defaults" delete "Apple Global Domain" ${domain}`);
-      } catch (ign) { }
-    };
-
-    beforeEach(async () => {
-      await clearFakeDomain();
+    before(async () => {
+      execStub = sinon.stub(TeenProcess, 'exec');
     });
 
     afterEach(async () => {
-      await clearFakeDomain();
+      execStub.restore();
     });
 
-    it('should get undefined for non-existent keys', async () => {
-      await getUserDefault(domain, 'hello').should.eventually.be.undefined;
-      await getUserDefault(domain, 'foo').should.eventually.be.undefined;
+    it('should parse the syntax that "defaults read ..." returns', async () => {
+      execStub.returns({
+        stdout: `{
+          "Toggle Enrolled State" = "foo";
+          "Touch ID Enrolled" = "bar";
+        }`,
+      });
+      await TouchEnroll.getUserDefault(undefined, 'Toggle Enrolled State').should.eventually.equal('foo');
+      await TouchEnroll.getUserDefault(undefined, 'Touch ID Enrolled').should.eventually.equal('bar');
     });
 
-    it('should set defaults', async () => {
-      await setUserDefault(domain, 'hello', 'world');
-      await getUserDefault(domain, 'hello').should.eventually.equal('world');
+    it('should return undefined if the value is nil', async () => {
+      execStub.returns({
+        stdout: `{
+          "Toggle Enrolled State" = nil;
+          "Touch ID Enrolled" = nil;
+        }`,
+      });
+      await TouchEnroll.getUserDefault(undefined, 'Toggle Enrolled State').should.eventually.not.exist;
+      await TouchEnroll.getUserDefault(undefined, 'Touch ID Enrolled').should.eventually.not.exist;
     });
 
-    it('should restore default to original value', async () => {
-      await setUserDefault(domain, 'hello', '1');
-      let originalValue = await getUserDefault(domain, 'hello');
-      originalValue.should.equal('1');
-      await setUserDefault(domain, 'hello', '2');
-      await getUserDefault(domain, 'hello').should.eventually.equal('2');
-      await setUserDefault(domain, 'hello', originalValue);
-      await getUserDefault(domain, 'hello').should.eventually.equal(originalValue);
+    it('should return undefined if the value is blank parantheses', async () => {
+      execStub.returns({
+        stdout: `{}`,
+      });
+      await TouchEnroll.getUserDefault(undefined, 'Toggle Enrolled State').should.eventually.not.exist;
+      await TouchEnroll.getUserDefault(undefined, 'Touch ID Enrolled').should.eventually.not.exist;
     });
 
-    it('should set multiple keys', async () => {
-      await setUserDefault(domain, 'hello', 'world');
-      await getUserDefault(domain, 'hello').should.eventually.equal('world');
-      await setUserDefault(domain, 'foo', 'bar');
-      await getUserDefault(domain, 'hello').should.eventually.equal('world');
-      await getUserDefault(domain, 'foo').should.eventually.equal('bar');
-      await setUserDefault(domain, 'hello', 'whirl');
-      await getUserDefault(domain, 'hello').should.eventually.equal('whirl');
-      await getUserDefault(domain, 'foo').should.eventually.equal('bar');
+    it('should return undefined if the call to exec throws a stderr', async () => {
+      execStub.throws();
+      await TouchEnroll.getUserDefault(undefined, 'Toggle Enrolled State').should.eventually.not.exist;
+      await TouchEnroll.getUserDefault(undefined, 'Touch ID Enrolled').should.eventually.not.exist;
+
     });
 
-    it('should set no value to nil', async () => {
-      await setUserDefault(domain, 'hello');
-      await getUserDefault(domain, 'hello').should.eventually.equal('nil');
-    });
-
-    it('should handle special characters', async () => {
-      await setUserDefault(domain, 'hello', TOUCH_ENROLL_KEY_CODE);
-      let firstRes = await getUserDefault(domain, 'hello').should.eventually.equal(TOUCH_ENROLL_KEY_CODE);
-      await setUserDefault(domain, 'hello', firstRes);
-      await getUserDefault(domain, 'hello').should.eventually.equal(firstRes);
-
-
-      await setUserDefault(domain, 'hello', '\\a');
-      firstRes = await getUserDefault(domain, 'hello').should.eventually.equal('\\a');
-      await setUserDefault(domain, 'hello', firstRes);
-      await getUserDefault(domain, 'hello').should.eventually.equal(firstRes);
-    });
   });
 
-  describe('setTouchEnrollKeys, getTouchEnrollKeys, setTouchEnrollKeys', () => {
-    beforeEach(async () => {
-      for (let key of touchEnrollMenuKeys) {
-        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, undefined);
-      }
-    });
-
-    it('should set the touch enroll keys', async () => {
-      await setTouchEnrollKey();
-      for (let key of touchEnrollMenuKeys) {
-        await getUserDefault(NS_USER_KEY_EQUIVALENTS, key).should.eventually.equal(TOUCH_ENROLL_KEY_CODE);
-      }
-    });
-
-    it('should save touch enroll keys', async () => {
-      let index = 0;
-      for (let key of touchEnrollMenuKeys) {
-        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, index++);
-      }
-      let keys = await getTouchEnrollKeys();
-      keys[0][1].should.equal('0');
-      keys[1][1].should.equal('1');
-    });
-
-    it('should restore touch enroll keys to their original values', async () => {
-      // Set the keys to 0 and 1 and then back them up
-      let index = 0;
-      for (let key of touchEnrollMenuKeys) {
-        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, index++);
-      } 
-      let backedUpKeys = await getTouchEnrollKeys();
-      backedUpKeys[0][1].should.equal('0');
-      backedUpKeys[1][1].should.equal('1');
-
-      // Set the keys to touch enroll shortcuts
-      await setTouchEnrollKey();
-      let keys = await getTouchEnrollKeys();
-      keys[0][1].should.equal(TOUCH_ENROLL_KEY_CODE);
-      keys[1][1].should.equal(TOUCH_ENROLL_KEY_CODE);
-
-      // Restore the keys and check that they are the same
-      await setTouchEnrollKeys(backedUpKeys);
-      let restoredKeys = await getTouchEnrollKeys();
-      restoredKeys[0][1].should.equal('0');
-      restoredKeys[1][1].should.equal('1');
-    });
-  });
-  
-  describe('backup and restore defaults', async () => {
-    async function setTouchEnrollMenuKeys (value) {
-      for (let key of touchEnrollMenuKeys) {
-        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, value);
-      }
-    }
-
-    beforeEach(async () => {
-      // Set the shortcuts to nothing
-      await setTouchEnrollMenuKeys();
-    });
-
-    it('should restore defaults after calling setTouchEnrollKey and then calling restore', async () => {
-      let originalValues = await getTouchEnrollKeys();
-      await setTouchEnrollKey();
-      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
-      await restoreTouchEnrollShortcuts();
-      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
-    });
-
-    it('should not do anything if restoring without backing up in the first place', async () => {
-      let originalValues = await getTouchEnrollKeys();
-      await restoreTouchEnrollShortcuts();
-      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
-    });
-
-    it('should restore to defaults even if we set touch enroll keys more than once', async () => {
-      let originalValues = await getTouchEnrollKeys();
-      await setTouchEnrollKey();
-      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
-      await setTouchEnrollKey();
-      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
-      await restoreTouchEnrollShortcuts();
-      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
-    });
-  });
 });

--- a/test/unit/touch-enroll-specs.js
+++ b/test/unit/touch-enroll-specs.js
@@ -1,0 +1,169 @@
+// transpile:mocha
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { exec as execNode } from 'child_process';
+import B from 'bluebird';
+import { getUserDefault, setUserDefault, setTouchEnrollKey, setTouchEnrollKeys, getTouchEnrollKeys, touchEnrollMenuKeys, 
+  restoreTouchEnrollShortcuts, NS_USER_KEY_EQUIVALENTS, TOUCH_ENROLL_KEY_CODE } from '../../lib/touch-enroll';
+
+const exec = B.promisify(execNode);
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('touch-enroll.js', () => {
+
+  describe('getUserDefaults(), setUserDefaults()', () => {
+    let domain = 'fakeDomain';
+
+  // Nuke the contents of the domain so it's fresh every test case
+    let clearFakeDomain = async function () {
+      try {
+        await exec(`"defaults" delete "Apple Global Domain" ${domain}`);
+      } catch (ign) { }
+    };
+
+    beforeEach(async () => {
+      await clearFakeDomain();
+    });
+
+    afterEach(async () => {
+      await clearFakeDomain();
+    });
+
+    it('should get undefined for non-existent keys', async () => {
+      await getUserDefault(domain, 'hello').should.eventually.be.undefined;
+      await getUserDefault(domain, 'foo').should.eventually.be.undefined;
+    });
+
+    it('should set defaults', async () => {
+      await setUserDefault(domain, 'hello', 'world');
+      await getUserDefault(domain, 'hello').should.eventually.equal('world');
+    });
+
+    it('should restore default to original value', async () => {
+      await setUserDefault(domain, 'hello', '1');
+      let originalValue = await getUserDefault(domain, 'hello');
+      originalValue.should.equal('1');
+      await setUserDefault(domain, 'hello', '2');
+      await getUserDefault(domain, 'hello').should.eventually.equal('2');
+      await setUserDefault(domain, 'hello', originalValue);
+      await getUserDefault(domain, 'hello').should.eventually.equal(originalValue);
+    });
+
+    it('should set multiple keys', async () => {
+      await setUserDefault(domain, 'hello', 'world');
+      await getUserDefault(domain, 'hello').should.eventually.equal('world');
+      await setUserDefault(domain, 'foo', 'bar');
+      await getUserDefault(domain, 'hello').should.eventually.equal('world');
+      await getUserDefault(domain, 'foo').should.eventually.equal('bar');
+      await setUserDefault(domain, 'hello', 'whirl');
+      await getUserDefault(domain, 'hello').should.eventually.equal('whirl');
+      await getUserDefault(domain, 'foo').should.eventually.equal('bar');
+    });
+
+    it('should set no value to nil', async () => {
+      await setUserDefault(domain, 'hello');
+      await getUserDefault(domain, 'hello').should.eventually.equal('nil');
+    });
+
+    it('should handle special characters', async () => {
+      await setUserDefault(domain, 'hello', TOUCH_ENROLL_KEY_CODE);
+      let firstRes = await getUserDefault(domain, 'hello').should.eventually.equal(TOUCH_ENROLL_KEY_CODE);
+      await setUserDefault(domain, 'hello', firstRes);
+      await getUserDefault(domain, 'hello').should.eventually.equal(firstRes);
+
+
+      await setUserDefault(domain, 'hello', '\\a');
+      firstRes = await getUserDefault(domain, 'hello').should.eventually.equal('\\a');
+      await setUserDefault(domain, 'hello', firstRes);
+      await getUserDefault(domain, 'hello').should.eventually.equal(firstRes);
+    });
+  });
+
+  describe('setTouchEnrollKeys, getTouchEnrollKeys, setTouchEnrollKeys', () => {
+    beforeEach(async () => {
+      for (let key of touchEnrollMenuKeys) {
+        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, undefined);
+      }
+    });
+
+    it('should set the touch enroll keys', async () => {
+      await setTouchEnrollKey();
+      for (let key of touchEnrollMenuKeys) {
+        await getUserDefault(NS_USER_KEY_EQUIVALENTS, key).should.eventually.equal(TOUCH_ENROLL_KEY_CODE);
+      }
+    });
+
+    it('should save touch enroll keys', async () => {
+      let index = 0;
+      for (let key of touchEnrollMenuKeys) {
+        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, index++);
+      }
+      let keys = await getTouchEnrollKeys();
+      keys[0][1].should.equal('0');
+      keys[1][1].should.equal('1');
+    });
+
+    it('should restore touch enroll keys to their original values', async () => {
+      // Set the keys to 0 and 1 and then back them up
+      let index = 0;
+      for (let key of touchEnrollMenuKeys) {
+        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, index++);
+      } 
+      let backedUpKeys = await getTouchEnrollKeys();
+      backedUpKeys[0][1].should.equal('0');
+      backedUpKeys[1][1].should.equal('1');
+
+      // Set the keys to touch enroll shortcuts
+      await setTouchEnrollKey();
+      let keys = await getTouchEnrollKeys();
+      keys[0][1].should.equal(TOUCH_ENROLL_KEY_CODE);
+      keys[1][1].should.equal(TOUCH_ENROLL_KEY_CODE);
+
+      // Restore the keys and check that they are the same
+      await setTouchEnrollKeys(backedUpKeys);
+      let restoredKeys = await getTouchEnrollKeys();
+      restoredKeys[0][1].should.equal('0');
+      restoredKeys[1][1].should.equal('1');
+    });
+  });
+  
+  describe('backup and restore defaults', async () => {
+    async function setTouchEnrollMenuKeys (value) {
+      for (let key of touchEnrollMenuKeys) {
+        await setUserDefault(NS_USER_KEY_EQUIVALENTS, key, value);
+      }
+    }
+
+    beforeEach(async () => {
+      // Set the shortcuts to nothing
+      await setTouchEnrollMenuKeys();
+    });
+
+    it('should restore defaults after calling setTouchEnrollKey and then calling restore', async () => {
+      let originalValues = await getTouchEnrollKeys();
+      await setTouchEnrollKey();
+      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
+      await restoreTouchEnrollShortcuts();
+      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
+    });
+
+    it('should not do anything if restoring without backing up in the first place', async () => {
+      let originalValues = await getTouchEnrollKeys();
+      await restoreTouchEnrollShortcuts();
+      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
+    });
+
+    it('should restore to defaults even if we set touch enroll keys more than once', async () => {
+      let originalValues = await getTouchEnrollKeys();
+      await setTouchEnrollKey();
+      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
+      await setTouchEnrollKey();
+      await getTouchEnrollKeys().should.eventually.not.deep.equal(originalValues);
+      await restoreTouchEnrollShortcuts();
+      await getTouchEnrollKeys().should.eventually.deep.equal(originalValues);
+    });
+  });
+});

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -13,6 +13,7 @@ import Simulator from '../../lib/simulator-xcode-6';
 import { fs } from 'appium-support';
 import path from 'path';
 
+
 chai.should();
 chai.use(chaiAsPromised);
 const expect = chai.expect;


### PR DESCRIPTION
* Wrote bindTouchIDKey() method which adds keyboard shortcut to Touch ID Enrollment menu items
* binds key on startup, unbinds key when it's killed
* Wrote enrollTouchID() method that calls Applescript to toggle the above keyboard shortcut
* Wrote unit test that checks that the call is not rejected (can't test the functionality in Simulator, those tests will be in XCUITest Driver)