### PR TITLE
Allow touchEnroll only if variable set to true

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -279,7 +279,7 @@ class SimulatorXcode6 extends EventEmitter {
     return indicator;
   }
 
-  async run (startupTimeout = this.startupTimeout) {
+  async run (startupTimeout = this.startupTimeout, allowTouchEnroll = false) {
     let simulatorApp = path.resolve(await getXcodePath(), 'Applications', this.simulatorApp);
     let args = ['-Fn', simulatorApp, '--args', '-CurrentDeviceUDID', this.udid];
     if (this.scaleFactor) {
@@ -292,8 +292,10 @@ class SimulatorXcode6 extends EventEmitter {
       args.push('-ConnectHardwareKeyboard', '0');
     }
 
-    // Do the 'Touch ID Enroll' key bindings before the Simulator starts
-    await setTouchEnrollKey();
+    // Set the 'Touch ID Enroll' key bindings before the Simulator starts
+    if (allowTouchEnroll) {
+      await setTouchEnrollKey();
+    }
 
     log.info(`Starting simulator with command: open ${args.join(' ')}`);
     let startTime = Date.now();

--- a/lib/touch-enroll.js
+++ b/lib/touch-enroll.js
@@ -86,5 +86,10 @@ async function restoreTouchEnrollShortcuts () {
   }
 }
 
-export { setTouchEnrollKey, getTouchEnrollKeys, setTouchEnrollKeys, getUserDefault, setUserDefault, touchEnrollMenuKeys, backupTouchEnrollShortcuts, restoreTouchEnrollShortcuts, 
+function getTouchEnrollBackups () {
+  return touchEnrollBackups;
+}
+
+export { setTouchEnrollKey, getTouchEnrollKeys, setTouchEnrollKeys, getUserDefault, setUserDefault, getTouchEnrollBackups,
+  touchEnrollMenuKeys, backupTouchEnrollShortcuts, restoreTouchEnrollShortcuts,
   NS_USER_KEY_EQUIVALENTS, TOUCH_ENROLL_KEY_CODE};


### PR DESCRIPTION
* Added 'allowTouchEnroll' as a param to `run` function
* If true, setTouchEnrollKeys is called
* Is not called if `allowTouchEnroll` is false
* Added test to check that enrollKeys are only backed up when `allowTouchEnroll === true`