### PR TITLE
Add method for dismissing possible Increase Database alert

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -16,6 +16,7 @@ import events from 'events';
 import Calendar from './calendar';
 const { EventEmitter } = events;
 
+
 const OPEN_TIMEOUT = 3000;
 const STARTUP_TIMEOUT = 60 * 1000;
 const EXTRA_STARTUP_TIME = 2000;
@@ -607,6 +608,14 @@ class SimulatorXcode6 extends EventEmitter {
       tell application "System Events"
         key code 17 using {control down, shift down, option down, command down}
       end tell
+    `]);
+  }
+
+  async dismissDatabaseAlert (increase = true) {
+    let button = increase ? 'Increase' : 'Cancel';
+    log.debug(`Attempting to dismiss database alert with '${button}' button`);
+    await exec('osascript', ['-e', `
+      activate application "Simulator"      tell application "System Events"      	tell process "Simulator"      		click button "${button}" of window 1      	end tell      end tell
     `]);
   }
 

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -615,7 +615,12 @@ class SimulatorXcode6 extends EventEmitter {
     let button = increase ? 'Increase' : 'Cancel';
     log.debug(`Attempting to dismiss database alert with '${button}' button`);
     await exec('osascript', ['-e', `
-      activate application "Simulator"      tell application "System Events"      	tell process "Simulator"      		click button "${button}" of window 1      	end tell      end tell
+      activate application "Simulator"
+      tell application "System Events"
+        tell process "Simulator"
+          click button "${button}" of window 1
+        end tell
+      end tell
     `]);
   }
 


### PR DESCRIPTION
AppleScript-based method to hit the "Increase Database" alert that comes up in Safari when a page requests logs of WebSQL/LocalStorage space. This button is not automatable through UI Automation or XCTest.