### PR TITLE
Make the code more compatible to multiple Simulators management

### DIFF
--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -8,9 +8,9 @@ import { getAppContainer, openUrl as simctlOpenUrl, terminate } from 'node-simct
 
 // these sims are sloooooooow
 const STARTUP_TIMEOUT = 120 * 1000;
-const SPRINGBOARD_PROCESS_NAME = 'com.apple.springboard';
-const MOBILE_SAFARI_PROCESS_NAME = 'com.apple.mobilesafari';
-const PROCESS_LAUNCH_OK_PATTERN = (name) => new RegExp(`${name.replace('.', '\\.')}:\\s+\\d+`);
+const SPRINGBOARD_BUNDLE_ID = 'com.apple.springboard';
+const MOBILE_SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
+const PROCESS_LAUNCH_OK_PATTERN = (bundleId) => new RegExp(`${bundleId.replace('.', '\\.')}:\\s+\\d+`);
 
 class SimulatorXcode8 extends SimulatorXcode7 {
   constructor (udid, xcodeVersion) {
@@ -36,8 +36,8 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     }
   }
 
-  get startupPollProcessName () {
-    return SPRINGBOARD_PROCESS_NAME;
+  get startupPollBundleId () {
+    return SPRINGBOARD_BUNDLE_ID;
   }
 
   get startupTimeout () {
@@ -53,8 +53,8 @@ class SimulatorXcode8 extends SimulatorXcode7 {
         try {
           // 'springboard' process should be the last one to start after boot
           // 'simctl launch' will block until this process is running or fail if booting is still in progress
-          const {stdout} = await exec('xcrun', ['simctl', 'launch', this.udid, this.startupPollProcessName]);
-          if (PROCESS_LAUNCH_OK_PATTERN(this.startupPollProcessName).test(stdout)) {
+          const {stdout} = await exec('xcrun', ['simctl', 'launch', this.udid, this.startupPollBundleId]);
+          if (PROCESS_LAUNCH_OK_PATTERN(this.startupPollBundleId).test(stdout)) {
             if (!isOnBootCompletedEmitted) {
               isOnBootCompletedEmitted = true;
               this.emit(BOOT_COMPLETED_EVENT);
@@ -85,8 +85,8 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       await waitForCondition(async () => {
         try {
           // This is to make sure Safari is already running
-          const {stdout} = await exec('xcrun', ['simctl', 'launch', this.udid, MOBILE_SAFARI_PROCESS_NAME]);
-          if (PROCESS_LAUNCH_OK_PATTERN(MOBILE_SAFARI_PROCESS_NAME).test(stdout)) {
+          const {stdout} = await exec('xcrun', ['simctl', 'launch', this.udid, MOBILE_SAFARI_BUNDLE_ID]);
+          if (PROCESS_LAUNCH_OK_PATTERN(MOBILE_SAFARI_BUNDLE_ID).test(stdout)) {
             await simctlOpenUrl(this.udid, url);
             return true;
           }
@@ -105,7 +105,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
 
   async cleanSafari (keepPrefs = true) {
     try {
-      await terminate(this.udid, MOBILE_SAFARI_PROCESS_NAME);
+      await terminate(this.udid, MOBILE_SAFARI_BUNDLE_ID);
     } catch (ign) {
       // ignore error
     }

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -70,7 +70,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       }, {waitMs: startupTimeout, intervalMs: 500});
     } catch (err) {
       log.errorAndThrow(`Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds because of ` +
-                        `"${lastError ? '"' + lastError + '"' : 'an unknown error'}"`);
+                        `"${lastError ? "`${lastError}`" : 'an unknown error'}"`);
     }
   }
 
@@ -97,7 +97,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       }, {waitMs: SAFARI_STARTUP_TIMEOUT, intervalMs: 500});
     } catch (err) {
       log.errorAndThrow(`Safari cannot open '${url}' after ${process.hrtime(launchTimestamp)[0]} seconds ` +
-                        `because of ${lastError ? '"' + lastError + '"' : 'an unknown error'}`);
+                        `because of ${lastError ? "`${lastError}`" : 'an unknown error'}`);
     }
     log.debug(`Safari has successfully opened '${url}' in ${process.hrtime(launchTimestamp)[0]} seconds`);
   }

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -3,7 +3,7 @@ import SimulatorXcode7 from './simulator-xcode-7';
 import log from './logger';
 import { waitForCondition } from 'asyncbox';
 import { exec } from 'teen_process';
-import { getAppContainer, openUrl as simctlOpenUrl } from 'node-simctl';
+import { getAppContainer, openUrl as simctlOpenUrl, terminate } from 'node-simctl';
 
 
 // these sims are sloooooooow
@@ -102,6 +102,16 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     }
     log.debug(`Safari has successfully opened '${url}' in ${process.hrtime(launchTimestamp)[0]} seconds`);
   }
+
+  async cleanSafari (keepPrefs = true) {
+    try {
+      await terminate(this.udid, MOBILE_SAFARI_PROCESS_NAME);
+    } catch (ign) {
+      // ignore error
+    }
+    await super.cleanSafari(keepPrefs);
+  }
+
 }
 
 export default SimulatorXcode8;

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -3,11 +3,14 @@ import SimulatorXcode7 from './simulator-xcode-7';
 import log from './logger';
 import { waitForCondition } from 'asyncbox';
 import { exec } from 'teen_process';
-import { getAppContainer } from 'node-simctl';
+import { getAppContainer, openUrl as simctlOpenUrl } from 'node-simctl';
 
 
 // these sims are sloooooooow
 const STARTUP_TIMEOUT = 120 * 1000;
+const SPRINGBOARD_PROCESS_NAME = 'com.apple.springboard';
+const MOBILE_SAFARI_PROCESS_NAME = 'com.apple.mobilesafari';
+const PROCESS_LAUNCH_OK_PATTERN = (name) => new RegExp(`${name.replace('.', '\\.')}:\\s+\\d+`);
 
 class SimulatorXcode8 extends SimulatorXcode7 {
   constructor (udid, xcodeVersion) {
@@ -33,49 +36,40 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     }
   }
 
+  get startupPollProcessName () {
+    return SPRINGBOARD_PROCESS_NAME;
+  }
+
   get startupTimeout () {
     return STARTUP_TIMEOUT;
   }
 
-  get startupPollCommand () {
-    return {
-      cmd: 'bash',
-      args: [
-        '-c',
-        'ps axo command | grep Simulator | grep nsurlstoraged | grep -v bash | grep -v grep'
-      ],
-    };
-  }
-
   async waitForBoot (startupTimeout) {
-    // wait for the simulator to boot
-    // waiting for the simulator status to be 'booted' isn't good enough
-    // it claims to be booted way before finishing loading
-    // let's wait for the magic nsurlstoraged process, which signals the booting has been completed
     const startupTimestamp = process.hrtime();
-    let {cmd, args} = this.startupPollCommand;
+    let lastError = null;
     try {
       let isOnBootCompletedEmitted = false;
       await waitForCondition(async () => {
         try {
-          let {stdout} = await exec(cmd, args);
-          if (stdout.trim().length > 0) {
+          // 'springboard' process should be the last one to start after boot
+          // 'simctl launch' will block until this process is running or fail if booting is still in progress
+          const {stdout} = await exec('xcrun', ['simctl', 'launch', this.udid, this.startupPollProcessName]);
+          if (PROCESS_LAUNCH_OK_PATTERN(this.startupPollProcessName).test(stdout)) {
             if (!isOnBootCompletedEmitted) {
               isOnBootCompletedEmitted = true;
               this.emit(BOOT_COMPLETED_EVENT);
             }
-            // 'springboard' process should be the last one to start after boot
-            // 'simctl launch' will block until this process is running
-            await exec('xcrun', ['simctl', 'launch', this.udid, 'com.apple.springboard']);
+
             return true;
           }
-        } catch (ign) {
-          // Continue iteration in case of error
+        } catch (err) {
+          lastError = err.stderr || err.message;
         }
         return false;
       }, {waitMs: startupTimeout, intervalMs: 500});
     } catch (err) {
-      log.errorAndThrow(`Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds`);
+      log.errorAndThrow(`Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds because of ` +
+                        `"${!!lastError ? '"' + lastError + '"' : 'an unknown error'}"`);
     }
   }
 
@@ -86,41 +80,28 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       throw new Error(`Tried to open ${url}, but Simulator is not in Booted state`);
     }
     const launchTimestamp = process.hrtime();
+    let lastError = null;
     try {
       await waitForCondition(async () => {
         try {
-          let stdout;
-          try {
-            // jshint ignore:start
-            ({stdout = ''} = await exec('bash',
-              ['-c', 'ps axo command | grep Simulator | grep MobileSafari | grep -v bash | grep -v grep']));
-            // jshint ignore:end
-          } catch (err) {
-            // error code 1 can be thrown in normal situations when nothing is found
-            if (err.code !== 1) {
-              throw err;
-            }
-            stdout = '';
+          // This is to make sure Safari is already running
+          const {stdout} = await exec('xcrun', ['simctl', 'launch', this.udid, MOBILE_SAFARI_PROCESS_NAME]);
+          if (PROCESS_LAUNCH_OK_PATTERN(MOBILE_SAFARI_PROCESS_NAME).test(stdout)) {
+            await simctlOpenUrl(this.udid, url);
+            return true;
           }
-          if (stdout.trim().length > 0) {
-            // Safari is already running. Open the url in the other tab
-            await exec('xcrun', ['simctl', 'openurl', this.udid, url]);
-          } else {
-            // Execute new Safari instance and open the url immediately
-            await exec('xcrun', ['simctl', 'launch', this.udid, 'com.apple.mobilesafari', url]);
-          }
-          return true;
-        } catch (e) {
+        } catch (err) {
           log.error(`Failed to open '${url}' in Safari. Retrying...`);
+          lastError = err.stderr || err.message;
         }
         return false;
       }, {waitMs: SAFARI_STARTUP_TIMEOUT, intervalMs: 500});
     } catch (err) {
-      log.errorAndThrow(`Safari cannot open '${url}' after ${process.hrtime(launchTimestamp)[0]} seconds`);
+      log.errorAndThrow(`Safari cannot open '${url}' after ${process.hrtime(launchTimestamp)[0]} seconds ` +
+                        `because of ${!!lastError ? '"' + lastError + '"' : 'an unknown error'}`);
     }
     log.debug(`Safari has successfully opened '${url}' in ${process.hrtime(launchTimestamp)[0]} seconds`);
   }
-
 }
 
 export default SimulatorXcode8;

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -8,6 +8,7 @@ import { getAppContainer, openUrl as simctlOpenUrl, terminate } from 'node-simct
 
 // these sims are sloooooooow
 const STARTUP_TIMEOUT = 120 * 1000;
+const SAFARI_STARTUP_TIMEOUT = 25 * 1000;
 const SPRINGBOARD_BUNDLE_ID = 'com.apple.springboard';
 const MOBILE_SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const PROCESS_LAUNCH_OK_PATTERN = (bundleId) => new RegExp(`${bundleId.replace('.', '\\.')}:\\s+\\d+`);
@@ -74,8 +75,6 @@ class SimulatorXcode8 extends SimulatorXcode7 {
   }
 
   async openUrl (url) {
-    const SAFARI_STARTUP_TIMEOUT = 15 * 1000;
-
     if (!await this.isRunning()) {
       throw new Error(`Tried to open ${url}, but Simulator is not in Booted state`);
     }

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -112,6 +112,15 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     await super.cleanSafari(keepPrefs);
   }
 
+  async cleanCustomApp (appFile, appBundleId, scrub = false) {
+    try {
+      await terminate(this.udid, appBundleId);
+    } catch (ign) {
+      // ignore error
+    }
+    await super.cleanCustomApp(appFile, appBundleId, scrub);
+  }
+
 }
 
 export default SimulatorXcode8;

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -69,7 +69,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       }, {waitMs: startupTimeout, intervalMs: 500});
     } catch (err) {
       log.errorAndThrow(`Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds because of ` +
-                        `"${!!lastError ? '"' + lastError + '"' : 'an unknown error'}"`);
+                        `"${lastError ? '"' + lastError + '"' : 'an unknown error'}"`);
     }
   }
 
@@ -98,7 +98,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       }, {waitMs: SAFARI_STARTUP_TIMEOUT, intervalMs: 500});
     } catch (err) {
       log.errorAndThrow(`Safari cannot open '${url}' after ${process.hrtime(launchTimestamp)[0]} seconds ` +
-                        `because of ${!!lastError ? '"' + lastError + '"' : 'an unknown error'}`);
+                        `because of ${lastError ? '"' + lastError + '"' : 'an unknown error'}`);
     }
     log.debug(`Safari has successfully opened '${url}' in ${process.hrtime(launchTimestamp)[0]} seconds`);
   }

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -1,4 +1,5 @@
 import SimulatorXcode8 from './simulator-xcode-8';
+import { shutdown as simctlShutdown } from 'node-simctl';
 
 
 class SimulatorXcode9 extends SimulatorXcode8 {
@@ -6,14 +7,8 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     super(udid, xcodeVersion);
   }
 
-  get startupPollCommand () {
-    return {
-      cmd: 'bash',
-      args: [
-        '-c',
-        'ps axo command | grep Simulator | grep SpringBoard | grep -v bash | grep -v grep'
-      ],
-    };
+  async shutdown () {
+    await simctlShutdown(this.udid);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bluebird": "^2.9.34",
     "fkill": "^4.1.0",
     "lodash": "^4.2.1",
-    "node-simctl": "^3.5.1",
+    "node-simctl": "^3.8.0",
     "openssl-wrapper": "^0.3.4",
     "semver-compare": "^1.0.0",
     "source-map-support": "^0.4.0",


### PR DESCRIPTION
We need to get rid of all the stuff, which does not work with simctl and the device udid directly (like grepping process names, killing all services by their names, and not by udid, etc), otherwise it will not be possible to isolate simulator interaction in scope of a single session and not to touch all the others parallel sessions running at the same time. We need also to think about adding headless simulator testing support.