### PR TITLE
Use more accurate isRunning detection

### DIFF
--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -74,6 +74,15 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     }
   }
 
+  async isRunning () {
+    try {
+      const {stdout} = await exec('xcrun', ['simctl', 'launch', this.udid, this.startupPollBundleId]);
+      return PROCESS_LAUNCH_OK_PATTERN(this.startupPollBundleId).test(stdout);
+    } catch (err) {
+      return false;
+    }
+  }
+
   async openUrl (url) {
     if (!await this.isRunning()) {
       throw new Error(`Tried to open ${url}, but Simulator is not in Booted state`);


### PR DESCRIPTION
The current verification may return true when the simulator is still in Booting state and is not ready to execute commands