### PR TITLE
Add headless capability support to Xcode 9 Simulator

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -71,7 +71,6 @@ class SimulatorXcode6 extends EventEmitter {
     if (newValue) {
       log.warn('The headless option has no effect on Simulator below Xcode9');
     }
-    this._isHeadless = !!newValue;
   }
 
   get isHeadless () {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -46,6 +46,7 @@ class SimulatorXcode6 extends EventEmitter {
 
     this.scaleFactor = null;
     this.connectHardwareKeyboard = null;
+    this._isHeadless = false;
 
     this.appDataBundlePaths = {};
 
@@ -64,6 +65,17 @@ class SimulatorXcode6 extends EventEmitter {
     this.extraStartupTime = EXTRA_STARTUP_TIME;
 
     this.calendar = new Calendar(this.getDir());
+  }
+
+  set isHeadless (newValue) {
+    if (newValue) {
+      log.warn('The headless option has no effect on Simulator below Xcode9');
+    }
+    this._isHeadless = !!newValue;
+  }
+
+  get isHeadless () {
+    return this._isHeadless;
   }
 
   get startupTimeout () {

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -69,8 +69,8 @@ class SimulatorXcode8 extends SimulatorXcode7 {
         return false;
       }, {waitMs: startupTimeout, intervalMs: 500});
     } catch (err) {
-      log.errorAndThrow(`Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds because of ` +
-                        `"${lastError ? "`${lastError}`" : 'an unknown error'}"`);
+      log.errorAndThrow(`Simulator is not booted after ${process.hrtime(startupTimestamp)[0]} seconds ` +
+                        `because of: ${lastError || 'an unknown error'}`);
     }
   }
 
@@ -97,7 +97,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       }, {waitMs: SAFARI_STARTUP_TIMEOUT, intervalMs: 500});
     } catch (err) {
       log.errorAndThrow(`Safari cannot open '${url}' after ${process.hrtime(launchTimestamp)[0]} seconds ` +
-                        `because of ${lastError ? "`${lastError}`" : 'an unknown error'}`);
+                        `because of: ${lastError || 'an unknown error'}`);
     }
     log.debug(`Safari has successfully opened '${url}' in ${process.hrtime(launchTimestamp)[0]} seconds`);
   }

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -1,10 +1,56 @@
 import SimulatorXcode8 from './simulator-xcode-8';
-import { shutdown as simctlShutdown } from 'node-simctl';
+import { exec } from 'teen_process';
+import log from './logger';
+import { shutdown as simctlShutdown, bootDevice } from 'node-simctl';
+import { waitForCondition } from 'asyncbox';
 
+
+const SIMULATOR_UI_APP_PATTERN = 'Simulator\\.app';
+const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
 
 class SimulatorXcode9 extends SimulatorXcode8 {
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
+  }
+
+  set isHeadless (newValue) {
+    this._isHeadless = !!newValue;
+  }
+
+  get isHeadless () {
+    return this._isHeadless;
+  }
+
+  async run (startupTimeout = this.startupTimeout, allowTouchEnroll = false) {
+    if (!this.isHeadless) {
+      return await super.run(startupTimeout, allowTouchEnroll);
+    }
+    log.info(`Booting the Simulator with UDID ${this.udid} in headless mode. All UI-related capabilities are going to be ignored.`);
+    const startTime = process.hrtime();
+    let wasUIClientKilled = false;
+    try {
+      await exec('pkill', ['-f', SIMULATOR_UI_APP_PATTERN]);
+      wasUIClientKilled = true;
+    } catch (ign) {
+      // ignore error
+    }
+    if (wasUIClientKilled) {
+      // Stopping the UI client also kills all running servers. Sad but true
+      log.info(`Detected the UI client is running and killed it. Verifying the Simulator is in Shutdown state...`);
+      await waitForCondition(async () => {
+        const {state} = await this.stat();
+        return state === 'Shutdown';
+      }, {waitMs: SIMULATOR_SHUTDOWN_TIMEOUT, intervalMs: 500});
+    }
+    try {
+      await bootDevice(this.udid);
+    } catch (err) {
+      // The device might be already booted, so we don't throw here
+      // and let the further boot detection to do the job
+      log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero return code. The problem was: ${err.stderr}`);
+    }
+    await this.waitForBoot(startupTimeout);
+    log.info(`Simulator booted in ${process.hrtime(startTime)[0]} seconds`);
   }
 
   async shutdown () {


### PR DESCRIPTION
Some adjustments are still needed to be done on xcuitest driver side, but this patch is not going to break anything anyway. It would be nice to have Xcode9-beta support on Travis, so we can create a functional test for the patch.