### PR TITLE
Fix Simulator startup if UI client is running under Xcode9

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -296,7 +296,11 @@ class SimulatorXcode6 extends EventEmitter {
       await setTouchEnrollKey();
     }
     if (await this.isUIClientRunning()) {
-      await simctl.bootDevice(this.udid);
+      try {
+        await bootDevice(this.udid);
+      } catch (err) {
+        log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero code. The problem was: ${err.stderr}`);
+      }
     } else {
       let simulatorApp = path.resolve(await getXcodePath(), 'Applications', this.simulatorApp);
       let args = ['-Fn', simulatorApp, '--args', '-CurrentDeviceUDID', this.udid];

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -297,7 +297,7 @@ class SimulatorXcode6 extends EventEmitter {
     }
     if (await this.isUIClientRunning()) {
       try {
-        await bootDevice(this.udid);
+        await simctl.bootDevice(this.udid);
       } catch (err) {
         log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero code. The problem was: ${err.stderr}`);
       }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -284,43 +284,43 @@ class SimulatorXcode6 extends EventEmitter {
     } catch (ign) {
       // ignore error
     }
-
-    let simulatorApp = path.resolve(await getXcodePath(), 'Applications', this.simulatorApp);
-    let args = ['-Fn', simulatorApp, '--args', '-CurrentDeviceUDID', this.udid];
     opts = Object.assign({
       scaleFactor: null,
       connectHardwareKeyboard: false,
       allowTouchEnroll: false,
       startupTimeout: this.startupTimeout,
     }, opts);
-
-    if (opts.scaleFactor) {
-      const supportedScales = ['1.0', '0.75', '0.5', '0.33', '0.25'];
-      if (supportedScales.indexOf(opts.scaleFactor) < 0) {
-        log.errorAndThrow(`Only "${supportedScales}" values are supported as scale factors. "${opts.scaleFactor}" is passed instead.`);
-      }
-      const stat = await this.stat();
-      const formattedDeviceName = stat.name.replace(/\s+/g, '-');
-      const argumentName = `-SimulatorWindowLastScale-com.apple.CoreSimulator.SimDeviceType.${formattedDeviceName}`;
-      args.push(argumentName, opts.scaleFactor);
-    }
-
-    if (!opts.connectHardwareKeyboard) {
-      args.push('-ConnectHardwareKeyboard', '0');
-    }
-
+    const startTime = process.hrtime();
     // Set the 'Touch ID Enroll' key bindings before the Simulator starts
     if (opts.allowTouchEnroll) {
       await setTouchEnrollKey();
     }
+    if (await this.isUIClientRunning()) {
+      await simctl.bootDevice(this.udid);
+    } else {
+      let simulatorApp = path.resolve(await getXcodePath(), 'Applications', this.simulatorApp);
+      let args = ['-Fn', simulatorApp, '--args', '-CurrentDeviceUDID', this.udid];
 
-    log.info(`Starting simulator with command: open ${args.join(' ')}`);
-    let startTime = Date.now();
-    await exec('open', args, {timeout: opts.startupTimeout});
+      if (opts.scaleFactor) {
+        const supportedScales = ['1.0', '0.75', '0.5', '0.33', '0.25'];
+        if (supportedScales.indexOf(opts.scaleFactor) < 0) {
+          log.errorAndThrow(`Only "${supportedScales}" values are supported as scale factors. "${opts.scaleFactor}" is passed instead.`);
+        }
+        const stat = await this.stat();
+        const formattedDeviceName = stat.name.replace(/\s+/g, '-');
+        const argumentName = `-SimulatorWindowLastScale-com.apple.CoreSimulator.SimDeviceType.${formattedDeviceName}`;
+        args.push(argumentName, opts.scaleFactor);
+      }
 
+      if (!opts.connectHardwareKeyboard) {
+        args.push('-ConnectHardwareKeyboard', '0');
+      }
+
+      log.info(`Starting Simulator UI with command: open ${args.join(' ')}`);
+      await exec('open', args, {timeout: opts.startupTimeout});
+    }
     await this.waitForBoot(opts.startupTimeout);
-
-    log.info(`Simulator booted in ${Date.now() - startTime}ms`);
+    log.info(`Simulator booted in ${process.hrtime(startTime)[0]} seconds`);
   }
 
   // TODO keep keychains

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -53,6 +53,10 @@ class SimulatorXcode9 extends SimulatorXcode8 {
 
   async shutdown () {
     await restoreTouchEnrollShortcuts();
+    const {state} = await this.stat();
+    if (state === 'Shutdown') {
+      return;
+    }
     await simctlShutdown(this.udid);
   }
 


### PR DESCRIPTION
This PR solves Simulator startup issue under Xcode9 in case if the UI client is already running (which is not the case for Xcode8 and earlier because shutdown call kills UI client there and we cannot do it under Xcode9, because it will kill all other booted Simulator instances).