### PR TITLE
Tune enroll backups logic not to break parallel tests

### DIFF
--- a/lib/touch-enroll.js
+++ b/lib/touch-enroll.js
@@ -92,7 +92,7 @@ async function backupTouchEnrollShortcuts () {
 async function restoreTouchEnrollShortcuts () {
   if (touchEnrollBackupsStack.length) {
     const preservedKeys = touchEnrollBackupsStack.pop();
-    if (!touchEnrollBackupsStack.length) {
+    if (preservedKeys) {
       await setTouchEnrollKeys(preservedKeys);
     }
   }

--- a/lib/touch-enroll.js
+++ b/lib/touch-enroll.js
@@ -1,7 +1,7 @@
 import { exec } from 'teen_process';
 
 let touchEnrollMenuKeys = ['Toggle Enrolled State', 'Touch ID Enrolled'];
-let touchEnrollBackups;
+const touchEnrollBackupsStack = [];
 const NS_USER_KEY_EQUIVALENTS = 'NSUserKeyEquivalents';
 const TOUCH_ENROLL_KEY_CODE = '@~$^t';
 
@@ -55,7 +55,7 @@ async function getUserDefault (domain, key) {
       return [key, value];
     });
 
-  
+
   for (let [testKey, value] of nsUserKeyArr) {
     if (testKey === key) {
       return value.replace(/\\\\/g, '\\');
@@ -65,29 +65,41 @@ async function getUserDefault (domain, key) {
 
 /**
  * Sets a MacOS User Default value on a domain
- * @param {*} domain 
- * @param {*} key 
- * @param {*} value 
+ * @param {*} domain
+ * @param {*} key
+ * @param {*} value
  */
 async function setUserDefault (domain, key, value) {
   await exec('defaults', ['write', 'Apple Global Domain', domain, '-dict-add', key, typeof(value) === 'undefined' ? 'nil' : value]);
 }
 
+/**
+ * Backup current values of user defaults and store them into an internal variable.
+ * Only one backup can be stored. All the further calls to this method will be ignored unless
+ * {#restoreTouchEnrollShortcuts} is called.
+ */
 async function backupTouchEnrollShortcuts () {
-  if (!touchEnrollBackups) {
-    touchEnrollBackups = await getTouchEnrollKeys();
+  if (!touchEnrollBackupsStack.length) {
+    touchEnrollBackupsStack.push(await getTouchEnrollKeys());
   }
 }
 
+/**
+ * Restore the user defaults previously preserved by {#backupTouchEnrollShortcuts}.
+ * Only one backup can be preserved. Multiple calls to this method
+ * will have no effect if the backup has already been restored or hasn't been made.
+ */
 async function restoreTouchEnrollShortcuts () {
-  if (touchEnrollBackups) {
-    await setTouchEnrollKeys(touchEnrollBackups);
-    touchEnrollBackups = undefined;
+  if (touchEnrollBackupsStack.length) {
+    const preservedKeys = touchEnrollBackupsStack.pop();
+    if (!touchEnrollBackupsStack.length) {
+      await setTouchEnrollKeys(preservedKeys);
+    }
   }
 }
 
 function getTouchEnrollBackups () {
-  return touchEnrollBackups;
+  return touchEnrollBackupsStack.length ? touchEnrollBackupsStack[touchEnrollBackupsStack.length - 1] : undefined;
 }
 
 export { setTouchEnrollKey, getTouchEnrollKeys, setTouchEnrollKeys, getUserDefault, setUserDefault, getTouchEnrollBackups,


### PR DESCRIPTION
Tune touch enroll tests to avoid the situation when parallel simulators unexpectedly change states of shared user defaults. This will, probably, will require some more work to prevent UI Apple scripts to be executed at the same time.