### PR TITLE
Add more logging to methods responsible for simulator startup and split logic between Xcode9 and earlier versions

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -311,7 +311,7 @@ class SimulatorXcode6 extends EventEmitter {
     const isServerRunning = state === 'Booted';
     const isUIClientRunning = await this.isUIClientRunning();
     if (isServerRunning && isUIClientRunning) {
-      log.info('Both Simulator with UDID ${this.udid} and the UI client are currently running. There\'s no need for restart.');
+      log.info(`Both Simulator with UDID ${this.udid} and the UI client are currently running`);
       return;
     }
     const startTime = process.hrtime();

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -7,7 +7,7 @@ import B from 'bluebird';
 import _ from 'lodash';
 import { killAllSimulators, safeRimRaf } from './utils.js';
 import { setTouchEnrollKey } from './touch-enroll.js';
-import { asyncmap, waitForCondition, retryInterval, retry } from 'asyncbox';
+import { asyncmap, retryInterval, waitForCondition, retry } from 'asyncbox';
 import * as settings from './settings';
 import { exec } from 'teen_process';
 import { tailUntil } from './tail-until.js';
@@ -19,6 +19,7 @@ const { EventEmitter } = events;
 
 const STARTUP_TIMEOUT = 60 * 1000;
 const EXTRA_STARTUP_TIME = 2000;
+
 /*
  * This event is emitted as soon as iOS Simulator
  * has finished booting and it is ready to accept xcrun commands.
@@ -272,59 +273,60 @@ class SimulatorXcode6 extends EventEmitter {
     return indicator;
   }
 
-  async run (opts = {}) {
-    if (await this.isRunning() && await this.isUIClientRunning()) {
-      log.info(`Simulator with udid '${this.udid}' already booted.`);
-      return;
-    }
-    log.info(`Simulator with udid '${this.udid}' not booted. Booting up now`);
-    try {
-      // Make sure Simulator is in Shutdown state before booting it
-      await this.shutdown();
-    } catch (ign) {
-      // ignore error
-    }
+  async startUIClient (opts = {}) {
     opts = Object.assign({
       scaleFactor: null,
       connectHardwareKeyboard: false,
+      startupTimeout: this.startupTimeout,
+    }, opts);
+
+    let simulatorApp = path.resolve(await getXcodePath(), 'Applications', this.simulatorApp);
+    let args = ['-Fn', simulatorApp, '--args', '-CurrentDeviceUDID', this.udid];
+
+    if (opts.scaleFactor) {
+      const supportedScales = ['1.0', '0.75', '0.5', '0.33', '0.25'];
+      if (supportedScales.indexOf(opts.scaleFactor) < 0) {
+        log.errorAndThrow(`Only "${supportedScales}" values are supported as scale factors. "${opts.scaleFactor}" is passed instead.`);
+      }
+      const stat = await this.stat();
+      const formattedDeviceName = stat.name.replace(/\s+/g, '-');
+      const argumentName = `-SimulatorWindowLastScale-com.apple.CoreSimulator.SimDeviceType.${formattedDeviceName}`;
+      args.push(argumentName, opts.scaleFactor);
+    }
+
+    if (!opts.connectHardwareKeyboard) {
+      args.push('-ConnectHardwareKeyboard', '0');
+    }
+
+    log.info(`Starting Simulator UI with command: open ${args.join(' ')}`);
+    await exec('open', args, {timeout: opts.startupTimeout});
+  }
+
+  async run (opts = {}) {
+    opts = Object.assign({
       allowTouchEnroll: false,
       startupTimeout: this.startupTimeout,
     }, opts);
+    const {state} = await this.stat();
+    const isServerRunning = state === 'Booted';
+    const isUIClientRunning = await this.isUIClientRunning();
+    if (isServerRunning && isUIClientRunning) {
+      log.info('Both Simulator with UDID ${this.udid} and the UI client are currently running. There\'s no need for restart.');
+      return;
+    }
     const startTime = process.hrtime();
+    try {
+      await this.shutdown();
+    } catch (err) {
+      log.warn(`Error on Simulator shutdown: ${err.message}`);
+    }
     // Set the 'Touch ID Enroll' key bindings before the Simulator starts
     if (opts.allowTouchEnroll) {
       await setTouchEnrollKey();
     }
-    if (await this.isUIClientRunning()) {
-      try {
-        await simctl.bootDevice(this.udid);
-      } catch (err) {
-        log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero code. The problem was: ${err.stderr}`);
-      }
-    } else {
-      let simulatorApp = path.resolve(await getXcodePath(), 'Applications', this.simulatorApp);
-      let args = ['-Fn', simulatorApp, '--args', '-CurrentDeviceUDID', this.udid];
-
-      if (opts.scaleFactor) {
-        const supportedScales = ['1.0', '0.75', '0.5', '0.33', '0.25'];
-        if (supportedScales.indexOf(opts.scaleFactor) < 0) {
-          log.errorAndThrow(`Only "${supportedScales}" values are supported as scale factors. "${opts.scaleFactor}" is passed instead.`);
-        }
-        const stat = await this.stat();
-        const formattedDeviceName = stat.name.replace(/\s+/g, '-');
-        const argumentName = `-SimulatorWindowLastScale-com.apple.CoreSimulator.SimDeviceType.${formattedDeviceName}`;
-        args.push(argumentName, opts.scaleFactor);
-      }
-
-      if (!opts.connectHardwareKeyboard) {
-        args.push('-ConnectHardwareKeyboard', '0');
-      }
-
-      log.info(`Starting Simulator UI with command: open ${args.join(' ')}`);
-      await exec('open', args, {timeout: opts.startupTimeout});
-    }
+    await this.startUIClient(opts);
     await this.waitForBoot(opts.startupTimeout);
-    log.info(`Simulator booted in ${process.hrtime(startTime)[0]} seconds`);
+    log.info(`Simulator with UDID ${this.udid} booted in ${process.hrtime(startTime)[0]} seconds`);
   }
 
   // TODO keep keychains

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -3,7 +3,8 @@ import { exec } from 'teen_process';
 import log from './logger';
 import { shutdown as simctlShutdown, bootDevice } from 'node-simctl';
 import { waitForCondition } from 'asyncbox';
-import { restoreTouchEnrollShortcuts, backupTouchEnrollShortcuts } from './touch-enroll.js';
+import { restoreTouchEnrollShortcuts, backupTouchEnrollShortcuts,
+         setTouchEnrollKey } from './touch-enroll.js';
 
 
 const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
@@ -18,37 +19,70 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       isHeadless: false,
       startupTimeout: this.startupTimeout,
     }, opts);
-    if (!opts.isHeadless) {
-      return await super.run(opts);
-    }
-    if (await this.isRunning() && !await this.isUIClientRunning()) {
-      log.info(`Simulator with udid '${this.udid}' already booted in headless mode.`);
-      return;
-    }
-    log.info(`Booting the Simulator with udid '${this.udid}' in headless mode. All UI-related capabilities are going to be ignored.`);
+    const {state} = await this.stat();
+    const isServerRunning = state === 'Booted';
+    const isUIClientRunning = await this.isUIClientRunning();
     const startTime = process.hrtime();
-    let wasUIClientKilled = false;
-    try {
-      await exec('pkill', ['-x', this.simulatorApp.split('.')[0]]);
-      wasUIClientKilled = true;
-    } catch (ign) {
-      // ignore error
-    }
-    if (wasUIClientKilled) {
-      // Stopping the UI client also kills all running servers. Sad but true
-      log.info(`Detected the UI client was running and killed it. Verifying the Simulator is in Shutdown state...`);
+    const bootSimulator = async () => {
+      try {
+        await bootDevice(this.udid);
+      } catch (err) {
+        log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero code. The problem was: ${err.stderr}`);
+      }
+    };
+    const waitForShutdown = async () => {
       await waitForCondition(async () => {
         const {state} = await this.stat();
         return state === 'Shutdown';
       }, {waitMs: SIMULATOR_SHUTDOWN_TIMEOUT, intervalMs: 500});
+    };
+    if (opts.isHeadless) {
+      if (isServerRunning && !isUIClientRunning) {
+        log.info(`Simulator with UDID ${this.udid} already booted in headless mode.`);
+        return;
+      }
+      log.info(`Booting the Simulator with UDID ${this.udid} in headless mode. All UI-related capabilities are going to be ignored.`);
+      let wasUIClientKilled = false;
+      try {
+        await exec('pkill', ['-x', this.simulatorApp.split('.')[0]]);
+        wasUIClientKilled = true;
+      } catch (ign) {
+        // ignore error
+      }
+      if (wasUIClientKilled) {
+        // Stopping the UI client also kills all running servers. Sad but true
+        log.info(`Detected the UI client was running and killed it. Verifying the Simulator is in Shutdown state...`);
+        await waitForShutdown();
+      }
+      await bootSimulator();
+    } else {
+      if (isServerRunning && isUIClientRunning) {
+        log.info('Both Simulator with UDID ${this.udid} and the UI client are currently running.');
+        return;
+      }
+      if (['Shutdown', 'Booted'].indexOf(state) === -1) {
+        log.info(`Simulator ${this.udid} is in '${state}' state. Trying to shutdown...`);
+        try {
+          await this.shutdown();
+        } catch (err) {
+          log.warn(`Error on Simulator shutdown: ${err.message}`);
+        }
+        await waitForShutdown();
+      }
+      // Set the 'Touch ID Enroll' key bindings before the Simulator starts
+      if (opts.allowTouchEnroll) {
+        await setTouchEnrollKey();
+      }
+      if (await this.isUIClientRunning()) {
+        log.info(`Booting Simulator with UDID ${this.udid} while UI client is running...`);
+        await bootSimulator();
+      } else {
+        await this.startUIClient(opts);
+      }
     }
-    try {
-      await bootDevice(this.udid);
-    } catch (err) {
-      log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero code. The problem was: ${err.stderr}`);
-    }
+
     await this.waitForBoot(opts.startupTimeout);
-    log.info(`Simulator booted in ${process.hrtime(startTime)[0]} seconds`);
+    log.info(`Simulator with UDID ${this.udid} booted in ${process.hrtime(startTime)[0]} seconds`);
   }
 
   async shutdown () {

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -17,6 +17,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
   async run (opts = {}) {
     opts = Object.assign({
       isHeadless: false,
+      allowTouchEnroll: false,
       startupTimeout: this.startupTimeout,
     }, opts);
     const {state} = await this.stat();

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -58,7 +58,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       await bootSimulator();
     } else {
       if (isServerRunning && isUIClientRunning) {
-        log.info('Both Simulator with UDID ${this.udid} and the UI client are currently running.');
+        log.info(`Both Simulator with UDID ${this.udid} and the UI client are currently running`);
         return;
       }
       if (['Shutdown', 'Booted'].indexOf(state) === -1) {


### PR DESCRIPTION
Made the code more readable and easier to debug from logs