### PR TITLE
Ensure the correct simulator is booted while UI client is running

### DIFF
--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -42,7 +42,6 @@ class SimulatorXcode9 extends SimulatorXcode8 {
         log.info(`Simulator with UDID ${this.udid} already booted in headless mode.`);
         return;
       }
-      log.info(`Booting the Simulator with UDID ${this.udid} in headless mode. All UI-related capabilities are going to be ignored.`);
       let wasUIClientKilled = false;
       try {
         await exec('pkill', ['-x', this.simulatorApp.split('.')[0]]);
@@ -55,6 +54,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
         log.info(`Detected the UI client was running and killed it. Verifying the Simulator is in Shutdown state...`);
         await waitForShutdown();
       }
+      log.info(`Booting Simulator with UDID ${this.udid} in headless mode. All UI-related capabilities are going to be ignored.`);
       await bootSimulator();
     } else {
       if (isServerRunning && isUIClientRunning) {
@@ -74,10 +74,9 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       if (opts.allowTouchEnroll) {
         await setTouchEnrollKey();
       }
-      if (await this.isUIClientRunning()) {
-        log.info(`Booting Simulator with UDID ${this.udid} while UI client is running...`);
-        await bootSimulator();
-      } else {
+      log.info(`Booting Simulator with UDID ${this.udid} while UI client is running...`);
+      await bootSimulator();
+      if (!await this.isUIClientRunning()) {
         await this.startUIClient(opts);
       }
     }


### PR DESCRIPTION
It looks like newer releases of Simulator UI client may ignore some arguments to start the particular client. That is why we try boot the correct server in any case independently of the UI state.