### PR TITLE
Stop testing ios 7.3 with xcode 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,57 +6,39 @@ env:
     - _FORCE_LOGS=1
 matrix:
   include:
-    - os: osx
-      osx_image: xcode7.3
+    - osx_image: xcode7.3
       node_js: "7"
       env: DEVICE=9.3
 
-    - os: osx
-      osx_image: xcode7.3
+    - osx_image: xcode7.3
       node_js: "6"
       env: DEVICE=9.3
 
-    - os: osx
-      osx_image: xcode8.3
+    - osx_image: xcode8.3
       node_js: "7"
       env: DEVICE=9.3
-    - os: osx
-      osx_image: xcode8.3
+    - osx_image: xcode8.3
       node_js: "7"
       env: DEVICE=10.3
 
-    - os: osx
-      osx_image: xcode8.3
+    - osx_image: xcode8.3
       node_js: "6"
       env: DEVICE=9.3
-    - os: osx
-      osx_image: xcode8.3
+    - osx_image: xcode8.3
       node_js: "6"
       env: DEVICE=10.3
 
-    - os: osx
-      osx_image: xcode9
-      node_js: "7"
-      env: DEVICE=9.3
-    - os: osx
-      osx_image: xcode9
+    - osx_image: xcode9
       node_js: "7"
       env: DEVICE=10.3
-    - os: osx
-      osx_image: xcode9
+    - osx_image: xcode9
       node_js: "7"
       env: DEVICE=11.0
 
-    - os: osx
-      osx_image: xcode9
-      node_js: "6"
-      env: DEVICE=9.3
-    - os: osx
-      osx_image: xcode9
+    - osx_image: xcode9
       node_js: "6"
       env: DEVICE=10.3
-    - os: osx
-      osx_image: xcode9
+    - osx_image: xcode9
       node_js: "6"
       env: DEVICE=11.0
 


### PR DESCRIPTION
Since Xcode 9 will signal the end of our support for iOS 7.3, there is no need to test that device with that xcode.

I also removed the redundant `os` specification, which is why the diff is so messed up.