### PR TITLE
Improve UI client state detection

### DIFF
--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -11,6 +11,7 @@ const STARTUP_TIMEOUT = 120 * 1000;
 const SAFARI_STARTUP_TIMEOUT = 25 * 1000;
 const SPRINGBOARD_BUNDLE_ID = 'com.apple.springboard';
 const MOBILE_SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
+const UI_CLIENT_BUNDLE_ID = 'com.apple.iphonesimulator';
 const PROCESS_LAUNCH_OK_PATTERN = (bundleId) => new RegExp(`${bundleId.replace('.', '\\.')}:\\s+\\d+`);
 
 class SimulatorXcode8 extends SimulatorXcode7 {
@@ -26,6 +27,30 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       'Library/Preferences/com.apple.springboard.plist',
       'var/run/syslog.pid'
     ];
+  }
+
+  /**
+   * @return {string} Bundle identifier of Simulator UI client.
+   */
+  get uiClientBundleId () {
+    return UI_CLIENT_BUNDLE_ID;
+  }
+
+  /**
+   * Check the state of Simulator UI client.
+   * @Override
+   *
+   * @return {boolean} True of if UI client is running or false otherwise.
+   */
+  async isUIClientRunning () {
+    const args = ['-e', `tell application "System Events" to count processes whose bundle identifier is "${this.uiClientBundleId}"`];
+    const {stdout} = await exec('osascript', args);
+    const count = parseInt(stdout, 10);
+    if (isNaN(count)) {
+      log.errorAndThrow(`Cannot parse the count of running Simulator UI client instances from 'osascript ${args}' output: ${stdout}`);
+    }
+    log.debug(`The count of running Simulator UI client instances is ${count}`);
+    return count >= 1;
   }
 
   /**

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -54,6 +54,25 @@ class SimulatorXcode8 extends SimulatorXcode7 {
   }
 
   /**
+   * Kill the UI client if it is running.
+   *
+   * @param {boolean} force - Set it to true to send SIGKILL signal to Simulator process.
+   *                          SIGTERM will be sent by default.
+   * @return {boolean} True if the UI client was successfully killed or false
+   *                   if it is not running.
+   */
+  async killUIClient (force = false) {
+    const osascriptArgs = ['-e', `tell application "System Events" to unix id of processes whose bundle identifier is "${this.uiClientBundleId}"`];
+    const {stdout} = await exec('osascript', osascriptArgs);
+    if (!stdout.trim().length) {
+      return false;
+    }
+    const killArgs = force ? ['-9', stdout.trim()] : [stdout.trim()];
+    await exec('kill', killArgs);
+    return true;
+  }
+
+  /**
    * Verify whether the particular application is installed on Simulator.
    * @override
    *

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -1,5 +1,6 @@
 import SimulatorXcode8 from './simulator-xcode-8';
 import { exec } from 'teen_process';
+import AsyncLock from 'async-lock';
 import log from './logger';
 import { shutdown as simctlShutdown, bootDevice } from 'node-simctl';
 import { waitForCondition } from 'asyncbox';
@@ -8,6 +9,7 @@ import { restoreTouchEnrollShortcuts, backupTouchEnrollShortcuts,
 
 
 const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
+const startupLock = new AsyncLock();
 
 class SimulatorXcode9 extends SimulatorXcode8 {
   constructor (udid, xcodeVersion) {
@@ -38,9 +40,13 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       allowTouchEnroll: false,
       startupTimeout: this.startupTimeout,
     }, opts);
-    const {state} = await this.stat();
-    const isServerRunning = state === 'Booted';
-    const isUIClientRunning = await this.isUIClientRunning();
+    let serverState, isServerRunning, isUIClientRunning;
+    await startupLock.acquire(this.uiClientBundleId, async () => {
+      const stat = await this.stat();
+      serverState = stat.state;
+      isServerRunning = serverState === 'Booted';
+      isUIClientRunning = await this.isUIClientRunning();
+    });
     const startTime = process.hrtime();
     const bootSimulator = async () => {
       try {
@@ -60,43 +66,47 @@ class SimulatorXcode9 extends SimulatorXcode8 {
         log.info(`Simulator with UDID ${this.udid} already booted in headless mode.`);
         return;
       }
-      let wasUIClientKilled = false;
-      try {
-        await exec('pkill', ['-x', this.simulatorApp.split('.')[0]]);
-        wasUIClientKilled = true;
-      } catch (ign) {
-        // ignore error
-      }
-      if (wasUIClientKilled) {
-        // Stopping the UI client also kills all running servers. Sad but true
-        log.info(`Detected the UI client was running and killed it. Verifying the Simulator is in Shutdown state...`);
-        await waitForShutdown();
-      }
-      log.info(`Booting Simulator with UDID ${this.udid} in headless mode. All UI-related capabilities are going to be ignored.`);
-      await bootSimulator();
+      await startupLock.acquire(this.uiClientBundleId, async () => {
+        let wasUIClientKilled = false;
+        try {
+          await exec('pkill', ['-x', this.simulatorApp.split('.')[0]]);
+          wasUIClientKilled = true;
+        } catch (ign) {
+          // ignore error
+        }
+        if (wasUIClientKilled) {
+          // Stopping the UI client also kills all running servers. Sad but true
+          log.info(`Detected the UI client was running and killed it. Verifying the Simulator is in Shutdown state...`);
+          await waitForShutdown();
+        }
+        log.info(`Booting Simulator with UDID ${this.udid} in headless mode. All UI-related capabilities are going to be ignored.`);
+        await bootSimulator();
+      });
     } else {
       if (isServerRunning && isUIClientRunning) {
         log.info(`Both Simulator with UDID ${this.udid} and the UI client are currently running`);
         return;
       }
-      if (['Shutdown', 'Booted'].indexOf(state) === -1) {
-        log.info(`Simulator ${this.udid} is in '${state}' state. Trying to shutdown...`);
-        try {
-          await this.shutdown();
-        } catch (err) {
-          log.warn(`Error on Simulator shutdown: ${err.message}`);
+      await startupLock.acquire(this.uiClientBundleId, async () => {
+        if (['Shutdown', 'Booted'].indexOf(serverState) === -1) {
+          log.info(`Simulator ${this.udid} is in '${serverState}' state. Trying to shutdown...`);
+          try {
+            await this.shutdown();
+          } catch (err) {
+            log.warn(`Error on Simulator shutdown: ${err.message}`);
+          }
+          await waitForShutdown();
         }
-        await waitForShutdown();
-      }
-      // Set the 'Touch ID Enroll' key bindings before the Simulator starts
-      if (opts.allowTouchEnroll) {
-        await setTouchEnrollKey();
-      }
-      log.info(`Booting Simulator with UDID ${this.udid}...`);
-      await bootSimulator();
-      if (!await this.isUIClientRunning()) {
-        await this.startUIClient(opts);
-      }
+        // Set the 'Touch ID Enroll' key bindings before the Simulator starts
+        if (opts.allowTouchEnroll) {
+          await setTouchEnrollKey();
+        }
+        log.info(`Booting Simulator with UDID ${this.udid}...`);
+        await bootSimulator();
+        if (!isUIClientRunning) {
+          await this.startUIClient(opts);
+        }
+      });
     }
 
     await this.waitForBoot(opts.startupTimeout);

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -92,7 +92,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       if (opts.allowTouchEnroll) {
         await setTouchEnrollKey();
       }
-      log.info(`Booting Simulator with UDID ${this.udid} while UI client is running...`);
+      log.info(`Booting Simulator with UDID ${this.udid}...`);
       await bootSimulator();
       if (!await this.isUIClientRunning()) {
         await this.startUIClient(opts);

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -53,11 +53,11 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       }, {waitMs: SIMULATOR_SHUTDOWN_TIMEOUT, intervalMs: 500});
     };
     let shouldWaitForBoot = true;
-    const stat = await this.stat();
-    const serverState = stat.state;
-    const isServerRunning = serverState === 'Booted';
     const startTime = process.hrtime();
     await startupLock.acquire(this.uiClientBundleId, async () => {
+      const stat = await this.stat();
+      const serverState = stat.state;
+      const isServerRunning = serverState === 'Booted';
       const isUIClientRunning = await this.isUIClientRunning();
       if (opts.isHeadless) {
         if (isServerRunning && !isUIClientRunning) {

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -1,5 +1,4 @@
 import SimulatorXcode8 from './simulator-xcode-8';
-import { exec } from 'teen_process';
 import AsyncLock from 'async-lock';
 import log from './logger';
 import { shutdown as simctlShutdown, bootDevice } from 'node-simctl';
@@ -40,14 +39,6 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       allowTouchEnroll: false,
       startupTimeout: this.startupTimeout,
     }, opts);
-    let serverState, isServerRunning, isUIClientRunning;
-    await startupLock.acquire(this.uiClientBundleId, async () => {
-      const stat = await this.stat();
-      serverState = stat.state;
-      isServerRunning = serverState === 'Booted';
-      isUIClientRunning = await this.isUIClientRunning();
-    });
-    const startTime = process.hrtime();
     const bootSimulator = async () => {
       try {
         await bootDevice(this.udid);
@@ -61,33 +52,32 @@ class SimulatorXcode9 extends SimulatorXcode8 {
         return state === 'Shutdown';
       }, {waitMs: SIMULATOR_SHUTDOWN_TIMEOUT, intervalMs: 500});
     };
-    if (opts.isHeadless) {
-      if (isServerRunning && !isUIClientRunning) {
-        log.info(`Simulator with UDID ${this.udid} already booted in headless mode.`);
-        return;
-      }
-      await startupLock.acquire(this.uiClientBundleId, async () => {
-        let wasUIClientKilled = false;
-        try {
-          await exec('pkill', ['-x', this.simulatorApp.split('.')[0]]);
-          wasUIClientKilled = true;
-        } catch (ign) {
-          // ignore error
+    let shouldWaitForBoot = true;
+    const stat = await this.stat();
+    const serverState = stat.state;
+    const isServerRunning = serverState === 'Booted';
+    const startTime = process.hrtime();
+    await startupLock.acquire(this.uiClientBundleId, async () => {
+      const isUIClientRunning = await this.isUIClientRunning();
+      if (opts.isHeadless) {
+        if (isServerRunning && !isUIClientRunning) {
+          log.info(`Simulator with UDID ${this.udid} already booted in headless mode.`);
+          shouldWaitForBoot = false;
+          return;
         }
-        if (wasUIClientKilled) {
+        if (await this.killUIClient()) {
           // Stopping the UI client also kills all running servers. Sad but true
           log.info(`Detected the UI client was running and killed it. Verifying the Simulator is in Shutdown state...`);
           await waitForShutdown();
         }
         log.info(`Booting Simulator with UDID ${this.udid} in headless mode. All UI-related capabilities are going to be ignored.`);
         await bootSimulator();
-      });
-    } else {
-      if (isServerRunning && isUIClientRunning) {
-        log.info(`Both Simulator with UDID ${this.udid} and the UI client are currently running`);
-        return;
-      }
-      await startupLock.acquire(this.uiClientBundleId, async () => {
+      } else {
+        if (isServerRunning && isUIClientRunning) {
+          log.info(`Both Simulator with UDID ${this.udid} and the UI client are currently running`);
+          shouldWaitForBoot = false;
+          return;
+        }
         if (['Shutdown', 'Booted'].indexOf(serverState) === -1) {
           log.info(`Simulator ${this.udid} is in '${serverState}' state. Trying to shutdown...`);
           try {
@@ -106,11 +96,13 @@ class SimulatorXcode9 extends SimulatorXcode8 {
         if (!isUIClientRunning) {
           await this.startUIClient(opts);
         }
-      });
-    }
+      }
+    });
 
-    await this.waitForBoot(opts.startupTimeout);
-    log.info(`Simulator with UDID ${this.udid} booted in ${process.hrtime(startTime)[0]} seconds`);
+    if (shouldWaitForBoot) {
+      await this.waitForBoot(opts.startupTimeout);
+      log.info(`Simulator with UDID ${this.udid} booted in ${process.hrtime(startTime)[0]} seconds`);
+    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "appium-support": "^2.4.0",
     "appium-xcode": "^3.1.0",
+    "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.9.34",


### PR DESCRIPTION
It looks like the current approach is not very stable in parallel tests (it always tries to start the UI client even if it is already running).