### PR TITLE
Avoid stopping simulator services before erase

### DIFF
--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -9,6 +9,7 @@ import { getAppContainer, openUrl as simctlOpenUrl, terminate } from 'node-simct
 // these sims are sloooooooow
 const STARTUP_TIMEOUT = 120 * 1000;
 const SAFARI_STARTUP_TIMEOUT = 25 * 1000;
+const UI_CLIENT_STARTUP_TIMEOUT = 5 * 1000;
 const SPRINGBOARD_BUNDLE_ID = 'com.apple.springboard';
 const MOBILE_SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const UI_CLIENT_BUNDLE_ID = 'com.apple.iphonesimulator';
@@ -70,6 +71,22 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     const killArgs = force ? ['-9', stdout.trim()] : [stdout.trim()];
     await exec('kill', killArgs);
     return true;
+  }
+
+  /**
+   * Start the Simulator UI client with the given arguments
+   * and wait until it is running.
+   * @override
+   */
+  async startUIClient (opts = {}) {
+    await super.startUIClient(opts);
+    try {
+      await waitForCondition(async () => {
+        return await this.isUIClientRunning();
+      }, {waitMs: UI_CLIENT_STARTUP_TIMEOUT, intervalMs: 300});
+    } catch (ign) {
+      log.warn(`The Simulator UI client is not running after ${UI_CLIENT_STARTUP_TIMEOUT} ms timeout`);
+    }
   }
 
   /**

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -1,7 +1,7 @@
 import SimulatorXcode8 from './simulator-xcode-8';
 import AsyncLock from 'async-lock';
 import log from './logger';
-import { shutdown as simctlShutdown, bootDevice } from 'node-simctl';
+import { shutdown as simctlShutdown, bootDevice, eraseDevice } from 'node-simctl';
 import { waitForCondition } from 'asyncbox';
 import { restoreTouchEnrollShortcuts, backupTouchEnrollShortcuts,
          setTouchEnrollKey } from './touch-enroll.js';
@@ -121,6 +121,15 @@ class SimulatorXcode9 extends SimulatorXcode8 {
   async enrollTouchID () {
     await backupTouchEnrollShortcuts();
     await super.enrollTouchID();
+  }
+
+  /**
+   * Reset the current Simulator to the clean state.
+   * @override
+   */
+  async clean () {
+    log.info(`Cleaning simulator ${this.udid}`);
+    await eraseDevice(this.udid, 10000);
   }
 }
 


### PR DESCRIPTION
It looks like stopping of Simulator services prevents simulator to be properly erased on Xcode9+.