### PR TITLE
Add a possibility to clear Simulator caches

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -776,7 +776,7 @@ class SimulatorXcode6 extends EventEmitter {
    */
   async clearCaches (...folderNames) {
     const cachesRoot = path.resolve(this.getDir(), 'Library', 'Caches');
-    if (!await fs.hasAccess(cachesRoot)) {
+    if (!(await fs.hasAccess(cachesRoot))) {
       log.debug(`Caches root at '${cachesRoot}' does not exist or is not accessible. Nothing to do there`);
       return 0;
     }
@@ -794,7 +794,11 @@ class SimulatorXcode6 extends EventEmitter {
 
     log.debug(`Matched ${itemsToRemove.length} Simulator cache ` +
       `item${itemsToRemove.length === 1 ? '' : 's'} for cleanup: ${itemsToRemove}`);
-    await B.all(itemsToRemove, (x) => fs.rimraf(x));
+    try {
+      await B.all(itemsToRemove, (x) => fs.rimraf(x));
+    } catch (e) {
+      log.warn(`Got an exception while cleaning Simulator caches: ${e.message}`);
+    }
     return itemsToRemove.length;
   }
 

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -436,10 +436,10 @@ class SimulatorXcode6 extends EventEmitter {
    *
    * @param {string} appFile - Application name minus ".app".
    * @param {string} appBundleId - Bundle identifier of the application.
-   * @return {array} Array of deletion promises.
+   * @return {array<Promise>} Array of deletion promises.
    */
   async scrubCustomApp (appFile, appBundleId) {
-    return await this.cleanCustomApp (appFile, appBundleId, true);
+    return await this.cleanCustomApp(appFile, appBundleId, true);
   }
 
   /**
@@ -450,7 +450,7 @@ class SimulatorXcode6 extends EventEmitter {
    * @param {boolean} scrub - If `scrub` is false, we want to clean by deleting the app and all
    *   files associated with it. If `scrub` is true, we just want to delete the preferences and
    *   changed files.
-   * @return {array} Array of deletion promises.
+   * @return {array<Promise>} Array of deletion promises.
    */
   async cleanCustomApp (appFile, appBundleId, scrub = false) {
     log.debug(`Cleaning app data files for '${appFile}', '${appBundleId}'`);
@@ -491,7 +491,7 @@ class SimulatorXcode6 extends EventEmitter {
    * @param {string} appBundleId - Bundle identifier of the application.
    * @param {boolean} scrub - The `Bundle` directory has the actual app in it. If we are just scrubbing,
    *   we want this to stay. If we are cleaning we delete.
-   * @return {array} Array of application data paths.
+   * @return {array<string>} Array of application data paths.
    */
   async getAppDirs (appFile, appBundleId, scrub = false) {
     let dirs = [];
@@ -765,6 +765,36 @@ class SimulatorXcode6 extends EventEmitter {
     } else {
       throw new Error('Tried to open a url, but the Simulator is not Booted');
     }
+  }
+
+  /**
+   * Perform Simulator caches cleanup.
+   *
+   * @param {?array<string>} folderNames - The names of Caches subfolders to be cleaned.
+   *   Non-accessible/non-existing subfolders will be skipped.
+   *   All existing subfolders under Caches will be deleted if this parameter is omitted.
+   * @returns {SimulatorXcode6} This instance for chaining.
+   */
+  async clearCaches (...folderNames) {
+    const cachesRoot = path.resolve(this.getDir(), 'Library', 'Caches');
+    if (!await fs.hasAccess(cachesRoot)) {
+      log.debug(`Caches root at '${cachesRoot}' does not exist or is not accessible. Nothing to do there`);
+      return this;
+    }
+
+    let itemsToRemove = folderNames.length ?
+      folderNames.map((x) => path.resolve(cachesRoot, x)) :
+      (await fs.readdir(cachesRoot)).map((x) => path.resolve(cachesRoot, x));
+    itemsToRemove = await B.filter(itemsToRemove, (x) => fs.hasAccess(x));
+    itemsToRemove = await B.filter(itemsToRemove, async (x) => (await fs.stat(x)).isDirectory());
+    if (!itemsToRemove.length) {
+      log.debug(`No Simulator cache items for cleanup were matched in '${cachesRoot}'`);
+      return this;
+    }
+
+    log.debug(`Matched ${itemsToRemove.length} Simulator cache items for cleanup: ${itemsToRemove}`);
+    await B.map(itemsToRemove, (x) => fs.rimraf(x));
+    return this;
   }
 
   /**

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -436,7 +436,6 @@ class SimulatorXcode6 extends EventEmitter {
    *
    * @param {string} appFile - Application name minus ".app".
    * @param {string} appBundleId - Bundle identifier of the application.
-   * @return {array<Promise>} Array of deletion promises.
    */
   async scrubCustomApp (appFile, appBundleId) {
     return await this.cleanCustomApp(appFile, appBundleId, true);
@@ -450,7 +449,6 @@ class SimulatorXcode6 extends EventEmitter {
    * @param {boolean} scrub - If `scrub` is false, we want to clean by deleting the app and all
    *   files associated with it. If `scrub` is true, we just want to delete the preferences and
    *   changed files.
-   * @return {array<Promise>} Array of deletion promises.
    */
   async cleanCustomApp (appFile, appBundleId, scrub = false) {
     log.debug(`Cleaning app data files for '${appFile}', '${appBundleId}'`);
@@ -770,31 +768,33 @@ class SimulatorXcode6 extends EventEmitter {
   /**
    * Perform Simulator caches cleanup.
    *
-   * @param {?array<string>} folderNames - The names of Caches subfolders to be cleaned.
+   * @param {...string} folderNames - The names of Caches subfolders to be cleaned.
    *   Non-accessible/non-existing subfolders will be skipped.
    *   All existing subfolders under Caches will be deleted if this parameter is omitted.
-   * @returns {SimulatorXcode6} This instance for chaining.
+   * @returns {number} The count of cleaned cache items.
+   *   Zero is returned if no items were for cleanup were matched (not accessible or not directories).
    */
   async clearCaches (...folderNames) {
     const cachesRoot = path.resolve(this.getDir(), 'Library', 'Caches');
     if (!await fs.hasAccess(cachesRoot)) {
       log.debug(`Caches root at '${cachesRoot}' does not exist or is not accessible. Nothing to do there`);
-      return this;
+      return 0;
     }
 
     let itemsToRemove = folderNames.length ?
       folderNames.map((x) => path.resolve(cachesRoot, x)) :
       (await fs.readdir(cachesRoot)).map((x) => path.resolve(cachesRoot, x));
-    itemsToRemove = await B.filter(itemsToRemove, (x) => fs.hasAccess(x));
     itemsToRemove = await B.filter(itemsToRemove, async (x) => (await fs.stat(x)).isDirectory());
+    itemsToRemove = await B.filter(itemsToRemove, (x) => fs.hasAccess(x));
     if (!itemsToRemove.length) {
       log.debug(`No Simulator cache items for cleanup were matched in '${cachesRoot}'`);
-      return this;
+      return 0;
     }
 
-    log.debug(`Matched ${itemsToRemove.length} Simulator cache items for cleanup: ${itemsToRemove}`);
-    await B.map(itemsToRemove, (x) => fs.rimraf(x));
-    return this;
+    log.debug(`Matched ${itemsToRemove.length} Simulator cache ` +
+      `item${itemsToRemove.length === 1 ? '' : 's'} for cleanup: ${itemsToRemove}`);
+    await B.all(itemsToRemove, (x) => fs.rimraf(x));
+    return itemsToRemove.length;
   }
 
   /**

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -781,11 +781,12 @@ class SimulatorXcode6 extends EventEmitter {
       return 0;
     }
 
-    let itemsToRemove = folderNames.length ?
-      folderNames.map((x) => path.resolve(cachesRoot, x)) :
-      (await fs.readdir(cachesRoot)).map((x) => path.resolve(cachesRoot, x));
+    let itemsToRemove = folderNames.length ? folderNames : (await fs.readdir(cachesRoot));
+    itemsToRemove = itemsToRemove.map((x) => path.resolve(cachesRoot, x));
+    if (folderNames.length) {
+      itemsToRemove = await B.filter(itemsToRemove, (x) => fs.hasAccess(x));
+    }
     itemsToRemove = await B.filter(itemsToRemove, async (x) => (await fs.stat(x)).isDirectory());
-    itemsToRemove = await B.filter(itemsToRemove, (x) => fs.hasAccess(x));
     if (!itemsToRemove.length) {
       log.debug(`No Simulator cache items for cleanup were matched in '${cachesRoot}'`);
       return 0;

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -772,7 +772,7 @@ class SimulatorXcode6 extends EventEmitter {
    *   Non-accessible/non-existing subfolders will be skipped.
    *   All existing subfolders under Caches will be deleted if this parameter is omitted.
    * @returns {number} The count of cleaned cache items.
-   *   Zero is returned if no items were for cleanup were matched (not accessible or not directories).
+   *   Zero is returned if no items were matched for cleanup (either not accessible or not directories).
    */
   async clearCaches (...folderNames) {
     const cachesRoot = path.resolve(this.getDir(), 'Library', 'Caches');


### PR DESCRIPTION
The next step will be to include the cleanup of `com.apple.mobile.installd.staging` cache folder into xcuitest driver lgorithm. See https://github.com/appium/appium/issues/9410 for more details.