### PR TITLE
Clean up stat function

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -242,19 +242,16 @@ class SimulatorXcode6 extends EventEmitter {
    * }
    */
   async stat () {
-    let devices = await simctl.getDevices();
-    let normalizedDevices = [];
-
-    // add sdk attribute to all entries, add to normalizedDevices
-    for (let [sdk, deviceArr] of _.toPairs(devices)) {
-      deviceArr = deviceArr.map((device) => {
-        device.sdk = sdk;
-        return device;
-      });
-      normalizedDevices = normalizedDevices.concat(deviceArr);
+    for (let [sdk, deviceArr] of _.toPairs(await simctl.getDevices())) {
+      for (let device of deviceArr) {
+        if (device.udid === this.udid) {
+          device.sdk = sdk;
+          return device;
+        }
+      }
     }
 
-    return _.find(normalizedDevices, {udid: this.udid});
+    return {};
   }
 
   /**


### PR DESCRIPTION
There is no reason to create a structure with all the info in it by iterating over all the devices, and then searching inside it (by iterating over the structure). 

We are already iterating over all the devices!