### PR TITLE
Add a method to clean the apps-related keychain

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -479,6 +479,13 @@ class SimulatorXcode6 extends EventEmitter {
   }
 
   /**
+   * Remove the apps-related keychain.
+   */
+  async cleanAppsKeychain () {
+    await fs.rimraf(path.resolve(this.keychainPath, 'keychain-2-debug.db'));
+  }
+
+  /**
    * Retrieve paths to dirs where application data is stored. iOS 8+ stores app data in two places,
    * and iOS 7.1 has only one directory
    *


### PR DESCRIPTION
Hello,

The application we are interested in testing has recently started storing data in the phone keychain. This results in persisting data across test sessions (e.g. a user is still logged in after uninstalling and reinstalling the app). However, we would like to remove this data in between test sessions. 

For the record, we do not want to remove every file in the keychain folder because we have a SSL certificate there that we would like to keep.
Also, we could not use the `fullReset` capability combined with the `customSSLCert` capability because we noticed the certificate was installed before the reset and was therefore deleted.
In any case, we would prefer not to destroy the simulator in between test sessions.

In the end, we found thanks to [this SO issue](https://stackoverflow.com/questions/41862997/ios-simulator-view-content-of-keychain) that removing a certain file in the simulator's keychain directory did the trick. Therefore, creating a method to remove this file and clean only the apps-related keychain seemed to be the best approach for our problem.
The idea is to then call it with `appium-xcuitest-driver` when a certain capability e.g. `keepKeychain` is set to `false`.

Any suggestion/improvement is welcome!