### PR TITLE
Update killAllSimulators helper

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -414,8 +414,16 @@ class SimulatorXcode6 extends EventEmitter {
       log.warn(`Error on Simulator shutdown: ${err.message}`);
     }
     await this.startUIClient(opts);
+
     await this.waitForBoot(opts.startupTimeout);
     log.info(`Simulator with UDID ${this.udid} booted in ${process.hrtime(startTime)[0]} seconds`);
+
+    try {
+      await waitForCondition(async () => await this.isUIClientRunning(),
+                             {waitMs: 5000, intervalMs: 1000});
+    } catch (e) {
+      log.errorAndThrow(`Simulator UI has not been shown in ${process.hrtime(startTime)[0]} seconds`);
+    }
   }
 
   // TODO keep keychains

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -417,13 +417,6 @@ class SimulatorXcode6 extends EventEmitter {
 
     await this.waitForBoot(opts.startupTimeout);
     log.info(`Simulator with UDID ${this.udid} booted in ${process.hrtime(startTime)[0]} seconds`);
-
-    try {
-      await waitForCondition(async () => await this.isUIClientRunning(),
-                             {waitMs: 5000, intervalMs: 1000});
-    } catch (e) {
-      log.errorAndThrow(`Simulator UI has not been shown in ${process.hrtime(startTime)[0]} seconds`);
-    }
   }
 
   // TODO keep keychains

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -10,7 +10,6 @@ import { getAppContainer, openUrl as simctlOpenUrl, terminate, appInfo } from 'n
 // these sims are sloooooooow
 const STARTUP_TIMEOUT = 120 * 1000;
 const SAFARI_STARTUP_TIMEOUT = 25 * 1000;
-const UI_CLIENT_STARTUP_TIMEOUT = 5 * 1000;
 const SPRINGBOARD_BUNDLE_ID = 'com.apple.springboard';
 const MOBILE_SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const UI_CLIENT_BUNDLE_ID = 'com.apple.iphonesimulator';
@@ -45,15 +44,12 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    * @return {boolean} True of if UI client is running or false otherwise.
    */
   async isUIClientRunning () {
-    let count = 0;
-    try {
-      const args = ['-e', `tell application "System Events" to count processes whose bundle identifier is '${this.uiClientBundleId}'`];
-      const {stdout} = await exec('osascript', args);
-      count = parseInt(stdout, 10);
-      if (isNaN(count)) {
-        log.errorAndThrow(`Cannot parse the count of running Simulator UI client instances from 'osascript ${args}' output: ${stdout}`);
-      }
-    } catch (ign) {}
+    const args = ['-e', `tell application "System Events" to count processes whose bundle identifier is "${this.uiClientBundleId}"`];
+    const {stdout} = await exec('osascript', args);
+    const count = parseInt(stdout.trim(), 10);
+    if (isNaN(count)) {
+      log.errorAndThrow(`Cannot parse the count of running Simulator UI client instances from 'osascript ${args}' output: ${stdout}`);
+    }
     log.debug(`The count of running Simulator UI client instances is ${count}`);
     return count >= 1;
   }
@@ -75,22 +71,6 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     const killArgs = force ? ['-9', stdout.trim()] : [stdout.trim()];
     await exec('kill', killArgs);
     return true;
-  }
-
-  /**
-   * Start the Simulator UI client with the given arguments
-   * and wait until it is running.
-   * @override
-   */
-  async startUIClient (opts = {}) {
-    await super.startUIClient(opts);
-    try {
-      await waitForCondition(async () => {
-        return await this.isUIClientRunning();
-      }, {waitMs: UI_CLIENT_STARTUP_TIMEOUT, intervalMs: 300});
-    } catch (ign) {
-      log.warn(`The Simulator UI client is not running after ${UI_CLIENT_STARTUP_TIMEOUT} ms timeout`);
-    }
   }
 
   /**

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -122,11 +122,6 @@ class SimulatorXcode9 extends SimulatorXcode8 {
         await bootSimulator();
         if (!isUIClientRunning) {
           await this.startUIClient(opts);
-          try {
-            await waitForCondition(async () => {
-              return await this.isUIClientRunning();
-            }, {waitMs: 5000, intervalMs: 1000});
-          } catch (ign) {}
         }
       }
     });
@@ -134,6 +129,14 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     if (shouldWaitForBoot) {
       await this.waitForBoot(opts.startupTimeout);
       log.info(`Simulator with UDID ${this.udid} booted in ${process.hrtime(startTime)[0]} seconds`);
+    }
+    if (!opts.isHeadless) {
+      try {
+        await waitForCondition(async () => await this.isUIClientRunning(),
+                               {waitMs: 5000, intervalMs: 1000});
+      } catch (e) {
+        log.errorAndThrow(`Simulator UI has not been shown in ${process.hrtime(startTime)[0]} seconds`);
+      }
     }
   }
 

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -122,6 +122,11 @@ class SimulatorXcode9 extends SimulatorXcode8 {
         await bootSimulator();
         if (!isUIClientRunning) {
           await this.startUIClient(opts);
+          try {
+            await waitForCondition(async () => {
+              return await this.isUIClientRunning();
+            }, {waitMs: 5000, intervalMs: 1000});
+          } catch (ign) {}
         }
       }
     });

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -130,14 +130,6 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       await this.waitForBoot(opts.startupTimeout);
       log.info(`Simulator with UDID ${this.udid} booted in ${process.hrtime(startTime)[0]} seconds`);
     }
-    if (!opts.isHeadless) {
-      try {
-        await waitForCondition(async () => await this.isUIClientRunning(),
-                               {waitMs: 5000, intervalMs: 1000});
-      } catch (e) {
-        log.errorAndThrow(`Simulator UI has not been shown in ${process.hrtime(startTime)[0]} seconds`);
-      }
-    }
   }
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,35 +40,46 @@ async function killAllSimulators (timeout = DEFAULT_SIM_SHUTDOWN_TIMEOUT) {
   const appName = xcodeVersion.major >= 7 ? 'Simulator' : 'iOS Simulator';
 
   // later versions are slower to close
-  timeout = timeout * (xcodeVersion.major === 8 ? 2 : 1);
+  timeout = timeout * (xcodeVersion.major >= 8 ? 2 : 1);
 
-  let pids;
   try {
-    let {stdout} = await exec('pgrep', ['-x', appName]);
-    pids = stdout.trim().split('\n').map((pid) => parseInt(pid, 10));
+    await exec('xcrun', ['simctl', 'shutdown', xcodeVersion.major > 8 ? 'all' : 'booted'], {timeout});
+  } catch (ign) {}
+
+  const pids = [];
+  try {
+    const {stdout} = await exec('osascript',
+      ['-e', `tell application "System Events" to unix id of processes whose bundle identifier is "com.apple.iphonesimulator"`]);
+    if (stdout.trim()) {
+      pids.push(...(stdout.trim().split(/\s+/)));
+    }
+  } catch (ign) {}
+  try {
+    const {stdout} = await exec('pgrep', ['-x', appName]);
+    if (stdout.trim()) {
+      pids.push(...(stdout.trim().split('\n')));
+    }
   } catch (e) {
-    if (e.code === 1) {
+    if (e.code === 1 && !pids.length) {
       log.debug(`${appName} is not running. Continuing...`);
       return;
     }
-    log.warn(`pgrep error ${e.code} while detecting whether ${appName} is running. Trying to kill anyway.`);
+    if (!pids.length) {
+      log.warn(`pgrep error ${e.code} while detecting whether ${appName} is running. Trying to kill anyway.`);
+    }
+  }
+  if (pids.length) {
+    const uniquePids = _.uniq(pids);
+    log.debug(`Using fkill to kill processes: ${uniquePids.join(', ')}`);
+    try {
+      await fkill(uniquePids, {force: true});
+    } catch (ign) {}
   }
 
-  await (async function performKill (pids = []) {
-    try {
-      await exec('xcrun', ['simctl', 'shutdown', 'booted'], {timeout});
-    } catch (ign) {}
-
-    if (pids.length) {
-      log.debug(`Using fkill to kill processes: ${pids.join(', ')}`);
-      try {
-        await fkill(pids, {force: true});
-      } catch (ign) {}
-    } else {
-      log.debug(`Using pkill to kill application: ${appName}`);
-      await pkill(appName, true);
-    }
-  })(pids);
+  log.debug(`Using pkill to kill application: ${appName}`);
+  try {
+    await pkill(appName, true);
+  } catch (ign) {}
 
   // wait for all the devices to be shutdown before Continuing
   // but only print out the failed ones when they are actually fully failed

--- a/test/functional/helpers.js
+++ b/test/functional/helpers.js
@@ -1,3 +1,14 @@
+import { waitForCondition } from 'asyncbox';
+
 const LONG_TIMEOUT = 480 * 1000;
 
-export { LONG_TIMEOUT };
+async function verifyStates (sim, shouldServerRun, shouldClientRun) {
+  const isServerRunning = await sim.isRunning();
+  isServerRunning.should.eql(shouldServerRun);
+  await waitForCondition(async () => {
+    const isClientRunning = await sim.isUIClientRunning();
+    return isClientRunning === shouldClientRun;
+  }, {waitMs: 60000, intervalMs: 5000});
+}
+
+export { LONG_TIMEOUT, verifyStates };

--- a/test/functional/helpers.js
+++ b/test/functional/helpers.js
@@ -1,14 +1,10 @@
-import { waitForCondition } from 'asyncbox';
-
 const LONG_TIMEOUT = 480 * 1000;
 
 async function verifyStates (sim, shouldServerRun, shouldClientRun) {
   const isServerRunning = await sim.isRunning();
   isServerRunning.should.eql(shouldServerRun);
-  await waitForCondition(async () => {
-    const isClientRunning = await sim.isUIClientRunning();
-    return isClientRunning === shouldClientRun;
-  }, {waitMs: 60000, intervalMs: 5000});
+  const isClientRunning = await sim.isUIClientRunning();
+  isClientRunning.should.eql(shouldClientRun);
 }
 
 export { LONG_TIMEOUT, verifyStates };

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -10,20 +10,13 @@ import { absolute as testAppPath } from 'ios-test-app';
 import { retryInterval } from 'asyncbox';
 import path from 'path';
 import xcode from 'appium-xcode';
-import { LONG_TIMEOUT } from './helpers';
+import { LONG_TIMEOUT, verifyStates } from './helpers';
 
 
 const BUNDLE_ID = 'io.appium.TestApp';
 
 chai.should();
 chai.use(chaiAsPromised);
-
-async function verifyStates (sim, shouldServerRun, shouldClientRun) {
-  const isServerRunning = await sim.isRunning();
-  isServerRunning.should.eql(shouldServerRun);
-  const isClientRunning = await sim.isUIClientRunning();
-  isClientRunning.should.eql(shouldClientRun);
-}
 
 function runTests (deviceType) {
   describe(`simulator ${deviceType.version}`, function () {
@@ -36,10 +29,10 @@ function runTests (deviceType) {
       if (!exists) {
         app = path.resolve(__dirname, '..', '..', '..', 'test', 'assets', 'TestApp-iphonesimulator.app');
       }
-      await killAllSimulators();
     });
 
     beforeEach(async function () {
+      await killAllSimulators();
       udid = await simctl.createDevice('ios-simulator testing',
                                        deviceType.device,
                                        deviceType.version,
@@ -48,13 +41,13 @@ function runTests (deviceType) {
       console.log('\n\n'); // eslint-disable-line no-console
     });
     afterEach(async function () {
+      await killAllSimulators();
       // only want to get rid of the device if it is present
       let devicePresent = (await simctl.getDevices())[deviceType.version]
         .filter((device) => {
           return device.udid === udid;
         }).length > 0;
       if (devicePresent) {
-        await killAllSimulators();
         await simctl.deleteDevice(udid);
       }
     });
@@ -307,6 +300,7 @@ function runTests (deviceType) {
       await B.delay(4000);
     });
     after(async function () {
+      await killAllSimulators();
       // only want to get rid of the device if it is present
       let devicePresent = (await simctl.getDevices())[deviceType.version]
         .filter((device) => {

--- a/test/functional/utils-e2e-specs.js
+++ b/test/functional/utils-e2e-specs.js
@@ -3,19 +3,11 @@ import { getSimulator, killAllSimulators } from '../..';
 import * as simctl from 'node-simctl';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { LONG_TIMEOUT } from './helpers';
-
+import { LONG_TIMEOUT, verifyStates } from './helpers';
 
 
 chai.should();
 chai.use(chaiAsPromised);
-
-async function verifyStates (sim, shouldServerRun, shouldClientRun) {
-  const isServerRunning = await sim.isRunning();
-  isServerRunning.should.eql(shouldServerRun);
-  const isClientRunning = await sim.isUIClientRunning();
-  isClientRunning.should.eql(shouldClientRun);
-}
 
 const deviceVersion = process.env.DEVICE ? process.env.DEVICE : '10.3';
 
@@ -24,15 +16,19 @@ describe('killAllSimulators', function () {
 
   let sim;
   beforeEach(async function () {
+    await killAllSimulators();
     let udid = await simctl.createDevice('ios-simulator testing',
                                          'iPhone 6s',
                                          deviceVersion,
-                                     20000);
+                                         20000);
     sim = await getSimulator(udid);
     await sim.run({startupTimeout: LONG_TIMEOUT});
   });
   afterEach(async function () {
-    await simctl.deleteDevice(sim.udid);
+    await killAllSimulators();
+    try {
+      await simctl.deleteDevice(sim.udid);
+    } catch (ign) {}
   });
   it('should be able to kill the simulators', async function () {
     await verifyStates(sim, true, true);

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -33,13 +33,6 @@ const XCODE_VERSION_8 = {
   minor: 2,
   patch: 1
 };
-const XCODE_VERSION_7 = {
-  versionString: '7.1.1',
-  versionFloat: 7.1,
-  major: 7,
-  minor: 1,
-  patch: 1
-};
 const XCODE_VERSION_6 = {
   versionString: '6.1.1',
   versionFloat: 6.1,
@@ -69,56 +62,35 @@ describe('util', () => {
   });
 
   describe('killAllSimulators', () => {
-    it('should call exec once if pgrep does not find any running Simulator with Xcode9', async () => {
+    it('should call exec thrice if pgrep does not find any running Simulator with Xcode9', async () => {
       xcodeMock.expects('getVersion').once().withArgs(true).returns(B.resolve(XCODE_VERSION_9));
+      execStub.withArgs('xcrun').returns();
+      execStub.withArgs('osascript').returns('');
       execStub.withArgs('pgrep').throws({code: 1});
-
-      await killAllSimulators();
-      execStub.calledOnce.should.be.true;
-    });
-    it('should call exec once if pgrep does not find any running Simulator with Xcode8', async () => {
-      xcodeMock.expects('getVersion').once().withArgs(true).returns(B.resolve(XCODE_VERSION_8));
-      execStub.withArgs('pgrep').throws({code: 1});
-
-      await killAllSimulators();
-      execStub.calledOnce.should.be.true;
-    });
-    it('should call exec thrice if pgrep does find running Simulator with Xcode7 and shutdown succeeds', async () => {
-      xcodeMock.expects('getVersion').once().withArgs(true).returns(B.resolve(XCODE_VERSION_7));
-      execStub.withArgs('pgrep').returns(0);
-      execStub.withArgs('xcrun').returns(0);
 
       await killAllSimulators();
       execStub.calledThrice.should.be.true;
     });
-    it('should call exec thrice if pgrep does find running Simulator with Xcode6 and shutdown fails', async () => {
+    it('should call exec thrice if pgrep does not find any running Simulator with Xcode8', async () => {
+      xcodeMock.expects('getVersion').once().withArgs(true).returns(B.resolve(XCODE_VERSION_8));
+      execStub.withArgs('xcrun').returns();
+      execStub.withArgs('osascript').throws();
+      execStub.withArgs('pgrep').throws({code: 1});
+
+      await killAllSimulators();
+      execStub.calledThrice.should.be.true;
+    });
+    it('should call exec 4 times if pgrep does find running Simulator with Xcode6 and shutdown fails', async () => {
       xcodeMock.expects('getVersion').once().withArgs(true).returns(B.resolve(XCODE_VERSION_6));
-      execStub.withArgs('pgrep').returns(0);
+      execStub.withArgs('pgrep').returns('0');
+      execStub.withArgs('osascript').returns('0');
       execStub.withArgs('xcrun').throws();
-      execStub.withArgs('pkill').returns(0);
+      execStub.withArgs('pkill').returns();
 
       try {
         await killAllSimulators(500);
       } catch (e) {}
-      execStub.calledThrice.should.be.true;
-    });
-    it('should call exec thrice if pgrep and simctl fail with Xcode8', async () => {
-      xcodeMock.expects('getVersion').once().withArgs(true).returns(B.resolve(XCODE_VERSION_8));
-      execStub.withArgs('pgrep').throws({code: 3});
-      execStub.withArgs('xcrun').throws();
-      execStub.withArgs('pkill').throws({code: 1});
-
-      await killAllSimulators(500).should.eventually.be.rejected;
-      execStub.calledThrice.should.be.true;
-    });
-    it('should call exec thrice if pgrep and simctl fail with Xcode9', async () => {
-      xcodeMock.expects('getVersion').once().withArgs(true).returns(B.resolve(XCODE_VERSION_9));
-      execStub.withArgs('pgrep').throws({code: 3});
-      execStub.withArgs('xcrun').throws();
-      execStub.withArgs('pkill').throws({code: 1});
-
-      await killAllSimulators(500).should.eventually.be.rejected;
-      execStub.calledThrice.should.be.true;
+      execStub.callCount.should.equal(4);
     });
   });
 


### PR DESCRIPTION
I observe that some functional tests on travis are failing because not all simulators are killed after this method is called. Lets try to fix this.