### PR TITLE
fix: call 'terminate safari' only for booted simulators

### DIFF
--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -192,7 +192,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    */
   async cleanSafari (keepPrefs = true) {
     try {
-      if (this.isRunning()) {
+      if (await this.isRunning()) {
           await terminate(this.udid, MOBILE_SAFARI_BUNDLE_ID);
       }
     } catch (ign) {

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -193,7 +193,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
   async cleanSafari (keepPrefs = true) {
     try {
       if (await this.isRunning()) {
-          await terminate(this.udid, MOBILE_SAFARI_BUNDLE_ID);
+        await terminate(this.udid, MOBILE_SAFARI_BUNDLE_ID);
       }
     } catch (ign) {
       // ignore error

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -192,7 +192,9 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    */
   async cleanSafari (keepPrefs = true) {
     try {
-      await terminate(this.udid, MOBILE_SAFARI_BUNDLE_ID);
+      if (this.isRunning()) {
+          await terminate(this.udid, MOBILE_SAFARI_BUNDLE_ID);
+      }
     } catch (ign) {
       // ignore error
     }


### PR DESCRIPTION
terminate safari only on booted simulators

this fix removes error 
[simctl] Error: simctl error running 'terminate': 
from log when we try to call 'terminate' on non-booted simulator.
See log example in https://github.com/appium/appium/issues/9954#issuecomment-360337526