### PR TITLE
Add 'hasSSLCert' to API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 // transpile:main
 
 import { getSimulator, getDeviceString } from './lib/simulator';
-import { killAllSimulators, endAllSimulatorDaemons, simExists, installSSLCert, uninstallSSLCert } from './lib/utils';
+import { killAllSimulators, endAllSimulatorDaemons, simExists, installSSLCert, uninstallSSLCert, hasSSLCert } from './lib/utils';
 import { BOOT_COMPLETED_EVENT } from './lib/simulator-xcode-6';
 
-export { getSimulator, getDeviceString, killAllSimulators, endAllSimulatorDaemons, simExists, installSSLCert, uninstallSSLCert,
+export { getSimulator, getDeviceString, killAllSimulators, endAllSimulatorDaemons, simExists, installSSLCert, uninstallSSLCert, hasSSLCert,
          BOOT_COMPLETED_EVENT };

--- a/index.js
+++ b/index.js
@@ -4,5 +4,14 @@ import { getSimulator, getDeviceString } from './lib/simulator';
 import { killAllSimulators, endAllSimulatorDaemons, simExists, installSSLCert, uninstallSSLCert, hasSSLCert } from './lib/utils';
 import { BOOT_COMPLETED_EVENT } from './lib/simulator-xcode-6';
 
-export { getSimulator, getDeviceString, killAllSimulators, endAllSimulatorDaemons, simExists, installSSLCert, uninstallSSLCert, hasSSLCert,
-         BOOT_COMPLETED_EVENT };
+export {
+  getSimulator,
+  getDeviceString,
+  killAllSimulators,
+  endAllSimulatorDaemons,
+  simExists,
+  installSSLCert,
+  uninstallSSLCert,
+  hasSSLCert,
+  BOOT_COMPLETED_EVENT
+};

--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -48,7 +48,7 @@ class Certificate {
     // If record is found, check fingerprints to verify that they didn't change
     let previousFingerprint = await trustStore.getFingerPrintFromRecord(subject);
     let currentFingerprint = await this.getFingerPrint();
-    return previousFingerprint === currentFingerprint.toString();
+    return previousFingerprint.toString() === currentFingerprint.toString();
   }
 
   /**
@@ -161,28 +161,38 @@ class TrustStore {
   }
 
   /**
-   * Remove record from tsettings
+   * Remove record from tsettings that matches the subject
+   * @param {string} subj
    */
   async removeRecord (subj) {
     return await execSQLiteQuery(await this.getDB(), `DELETE FROM tsettings WHERE subj = '?'`, subj);
   }
 
   /**
-   * Get a record from tsettings
+   * Get a record from tsettings that matches the subj
+   * @param {string} subj
    */
   async hasRecords (subj) {
     return (await this.getRecordCount(subj)) > 0;
   }
 
+  /**
+   * Get count of how many records have this subject
+   * @param {string} subj
+   */
   async getRecordCount (subj) {
     let result =  (await execSQLiteQuery(await this.getDB(), `SELECT count(*) FROM tsettings WHERE subj = '?'`, subj)).stdout;
     return parseInt(result.split('=')[1], 10);
   }
 
+  /**
+   * Get the SHA1 fingerprint for the record that has this subject
+   * @param {string} subj
+   */
   async getFingerPrintFromRecord (subj) {
     let result = (await execSQLiteQuery(await this.getDB(), `SELECT sha1 FROM tsettings WHERE subj='?'`, subj)).stdout;
     if (result) {
-      return result.split('=')[1].trim();
+      return new Buffer(result.split('=')[1].trim());
     }
   }
 }

--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -39,7 +39,16 @@ class Certificate {
   async has (dir) {
     let subject = await this.getSubject(this.pemFilename);
     let trustStore = new TrustStore(dir);
-    return await trustStore.hasRecords(subject);
+
+    // Return false if record with this subject is not found
+    if (!await trustStore.hasRecords(subject)) {
+      return false;
+    }
+
+    // If record is found, check fingerprints to verify that they didn't change
+    let previousFingerprint = await trustStore.getFingerPrintFromRecord(subject);
+    let currentFingerprint = await this.getFingerPrint();
+    return previousFingerprint === currentFingerprint.toString();
   }
 
   /**
@@ -168,6 +177,13 @@ class TrustStore {
   async getRecordCount (subj) {
     let result =  (await execSQLiteQuery(await this.getDB(), `SELECT count(*) FROM tsettings WHERE subj = '?'`, subj)).stdout;
     return parseInt(result.split('=')[1], 10);
+  }
+
+  async getFingerPrintFromRecord (subj) {
+    let result = (await execSQLiteQuery(await this.getDB(), `SELECT sha1 FROM tsettings WHERE subj='?'`, subj)).stdout;
+    if (result) {
+      return result.split('=')[1].trim();
+    }
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ import { exec } from 'teen_process';
 import { waitForCondition } from 'asyncbox';
 import { getVersion } from 'appium-xcode';
 import { getDevices } from 'node-simctl';
-import { fs } from 'appium-support';
+import { fs, tempDir } from 'appium-support';
 import { Certificate } from './certificate';
 import path from 'path';
 import Simulator from './simulator-xcode-6';
@@ -176,6 +176,11 @@ async function safeRimRaf (delPath, tryNum = 0) {
   }
 }
 
+/**
+ * Install an SSL certificate to a device with given udid
+ * @param {string} pemText SSL pem text
+ * @param {string} udid Identifier of the Simulator
+ */
 async function installSSLCert (pemText, udid) {
   // Check that openssl is installed on the path
   try {
@@ -193,8 +198,10 @@ async function installSSLCert (pemText, udid) {
     log.errorAndThrow(`Command 'sqlite3' not found`);
   }
 
-  let tempFileName = path.resolve(`${__dirname}/temp-ssl-cert.pem`);
-  let pathToKeychain = path.resolve(new Simulator(udid).getDir());
+  // Create a temporary file to store PEM text
+  // (a temp file is necessary to run `openssl` shell commands, can't be done in memory)
+  let tempFileName = path.resolve(await tempDir.openDir(), 'temp-ssl-cert.pem');
+  let pathToKeychain = new Simulator(udid).getDir();
   await fs.writeFile(tempFileName, pemText);
   try {
     await fs.stat(pathToKeychain);
@@ -202,9 +209,13 @@ async function installSSLCert (pemText, udid) {
     log.debug(`Could not install SSL certificate. No simulator with udid '${udid}'`);
     log.errorAndThrow(e);
   }
+
+  // Do the certificate installation
   let certificate = new Certificate(tempFileName);
   log.debug(`Installing certificate to ${pathToKeychain}`);
   await certificate.add(pathToKeychain);
+
+  // Remove the temporary file
   await fs.unlink(tempFileName);
 
   return certificate;
@@ -225,11 +236,16 @@ async function uninstallSSLCert (pemText, udid) {
   }
 }
 
+/**
+ * Check if the Simulator already has this SSL certificate
+ * @param {string} pemText PEM text of SSL cert
+ * @param {string} udid Identifier of the Simulator
+ */
 async function hasSSLCert (pemText, udid) {
-  let tempFileName = path.resolve(`${__dirname}/temp-ssl-cert.pem`);
-  let pathToKeychain = path.resolve(new Simulator(udid).getDir());
+  const tempFileName = path.resolve(await tempDir.openDir(), 'temp-ssl-cert.pem');
+  const pathToKeychain = new Simulator(udid).getDir();
   await fs.writeFile(tempFileName, pemText);
-  let certificate = new Certificate(tempFileName);
+  const certificate = new Certificate(tempFileName);
   return certificate.has(pathToKeychain);
 }
 
@@ -248,4 +264,13 @@ async function execSQLiteQuery (db, query, ...queryParams) {
   return await exec('sqlite3', ['-line', db, formattedQuery.join('')]);
 }
 
-export { killAllSimulators, endAllSimulatorDaemons, safeRimRaf, simExists, installSSLCert, uninstallSSLCert, hasSSLCert, execSQLiteQuery };
+export {
+  killAllSimulators,
+  endAllSimulatorDaemons,
+  safeRimRaf,
+  simExists,
+  installSSLCert,
+  uninstallSSLCert,
+  hasSSLCert,
+  execSQLiteQuery
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -206,6 +206,7 @@ async function installSSLCert (pemText, udid) {
   log.debug(`Installing certificate to ${pathToKeychain}`);
   await certificate.add(pathToKeychain);
   await fs.unlink(tempFileName);
+
   return certificate;
 }
 
@@ -224,6 +225,14 @@ async function uninstallSSLCert (pemText, udid) {
   }
 }
 
+async function hasSSLCert (pemText, udid) {
+  let tempFileName = path.resolve(`${__dirname}/temp-ssl-cert.pem`);
+  let pathToKeychain = path.resolve(new Simulator(udid).getDir());
+  await fs.writeFile(tempFileName, pemText);
+  let certificate = new Certificate(tempFileName);
+  return certificate.has(pathToKeychain);
+}
+
 /**
  * Runs a command line sqlite3 query
  */
@@ -239,4 +248,4 @@ async function execSQLiteQuery (db, query, ...queryParams) {
   return await exec('sqlite3', ['-line', db, formattedQuery.join('')]);
 }
 
-export { killAllSimulators, endAllSimulatorDaemons, safeRimRaf, simExists, installSSLCert, uninstallSSLCert, execSQLiteQuery };
+export { killAllSimulators, endAllSimulatorDaemons, safeRimRaf, simExists, installSSLCert, uninstallSSLCert, hasSSLCert, execSQLiteQuery };

--- a/test/unit/certificate-specs.js
+++ b/test/unit/certificate-specs.js
@@ -79,6 +79,10 @@ describe('when using Certificate class', () => {
     certificate = await new Certificate(`${assetsDir}/test-pem.pem`);
   });
 
+  afterEach(async () => {
+    await certificate.remove(assetsDir);
+  });
+
   it('can translate PEM certificate to DER format', async () => {
     let derData = await certificate.getDerData();
     let testData = await fs.readFile(`${assetsDir}/Library/certificates/test-data.txt`);
@@ -98,9 +102,9 @@ describe('when using Certificate class', () => {
   });
 
   it('can add a certificate to a sqlite store', async () => {
+    await certificate.has(assetsDir).should.eventually.be.false;
     await certificate.add(assetsDir);
-    let hasCert = await certificate.has(assetsDir);
-    expect(hasCert);
+    await certificate.has(assetsDir).should.eventually.be.true;
   });
 
   it('can add and remove a certificate to a sqlite store', async () => {


### PR DESCRIPTION
* Exposed 'hasSSLCert' to API which checks new pemText to check if it already exists as an entry in the Trust Store
* Updated the certificate.has method to check fingerprint too
  * If the subj is there but fingerprint is different, then it returns false
  * If subj and sha1 are unchanged, then it returns true
  * This is so that we can check if a cert is already installed, and if it is, we don't have to restart simulator