### PR TITLE
Add method to get ios 9.3 web inspector socket

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -1132,6 +1132,10 @@ class SimulatorXcode6 extends EventEmitter {
     return iosDeviceString;
   }
 
+  /*
+   * @return {string} The full path to the simulator's WebInspector Unix Domain Socket
+  *                   or `null` if there is no socket.
+   */
   async getWebInspectorSocket () {
     // there is no WebInspector socket for this version of Xcode
     return null;

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -1131,6 +1131,11 @@ class SimulatorXcode6 extends EventEmitter {
     log.debug(`Final device string is '${iosDeviceString}'`);
     return iosDeviceString;
   }
+
+  async getWebInspectorSocket () {
+    // there is no WebInspector socket for this version of Xcode
+    return null;
+  }
 }
 
 for (let [cmd, fn] of _.toPairs(extensions)) {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -1133,8 +1133,8 @@ class SimulatorXcode6 extends EventEmitter {
   }
 
   /*
-   * @return {string} The full path to the simulator's WebInspector Unix Domain Socket
-  *                   or `null` if there is no socket.
+   * @return {?string} The full path to the simulator's WebInspector Unix Domain Socket
+   *   or `null` if there is no socket.
    */
   async getWebInspectorSocket () {
     // there is no WebInspector socket for this version of Xcode

--- a/lib/simulator-xcode-9.3.js
+++ b/lib/simulator-xcode-9.3.js
@@ -1,0 +1,47 @@
+import SimulatorXcode9 from './simulator-xcode-9';
+import { exec } from 'teen_process';
+
+
+class SimulatorXcode93 extends SimulatorXcode9 {
+  constructor (udid, xcodeVersion) {
+    super(udid, xcodeVersion);
+
+    this.webInspectorSocket = null;
+  }
+
+  async getWebInspectorSocket () {
+    if (this.webInspectorSocket) {
+      return this.webInspectorSocket;
+    }
+
+    // lsof -aUc launchd_sim
+    // gives a set of records like:
+    //   launchd_s 69760 isaac    3u  unix 0x57aa4fceea3937f3      0t0      /private/tmp/com.apple.CoreSimulator.SimDevice.D7082A5C-34B5-475C-994E-A21534423B9E/syslogsock
+    //   launchd_s 69760 isaac    5u  unix 0x57aa4fceea395f03      0t0      /private/tmp/com.apple.launchd.2B2u8CkN8S/Listeners
+    //   launchd_s 69760 isaac    6u  unix 0x57aa4fceea39372b      0t0      ->0x57aa4fceea3937f3
+    //   launchd_s 69760 isaac    8u  unix 0x57aa4fceea39598b      0t0      /private/tmp/com.apple.launchd.2j5k1TMh6i/com.apple.webinspectord_sim.socket
+    //   launchd_s 69760 isaac    9u  unix 0x57aa4fceea394c43      0t0      /private/tmp/com.apple.launchd.4zm9JO9KEs/com.apple.testmanagerd.unix-domain.socket
+    //   launchd_s 69760 isaac   10u  unix 0x57aa4fceea395f03      0t0      /private/tmp/com.apple.launchd.2B2u8CkN8S/Listeners
+    //   launchd_s 69760 isaac   11u  unix 0x57aa4fceea39598b      0t0      /private/tmp/com.apple.launchd.2j5k1TMh6i/com.apple.webinspectord_sim.socket
+    //   launchd_s 69760 isaac   12u  unix 0x57aa4fceea394c43      0t0      /private/tmp/com.apple.launchd.4zm9JO9KEs/com.apple.testmanagerd.unix-domain.socket
+    // these _appear_ to always be grouped together (so, the records for the particular sim are all in a group, before the next sim, etc.)
+    // so starting from the correct UDID, we ought to be able to pull the next record with `com.apple.webinspectord_sim.socket` to get the correct socket
+    let {stdout} = await exec('lsof', ['-aUc', 'launchd_sim']);
+    for (let record of stdout.split('com.apple.CoreSimulator.SimDevice.')) {
+      if (!record.includes(this.udid)) {
+        continue;
+      }
+      // console.log('we got the record for the udid');
+      // console.log(record);
+      // https://regex101.com/r/MEL55t/1
+      const match = /\s+(\S+com\.apple\.webinspectord_sim\.socket)/.exec(record);
+      if (!match) {
+        return null;
+      }
+      this.webInspectorSocket = match[1];
+      return this.webInspectorSocket;
+    }
+  }
+}
+
+export default SimulatorXcode93;

--- a/lib/simulator-xcode-9.3.js
+++ b/lib/simulator-xcode-9.3.js
@@ -2,6 +2,9 @@ import SimulatorXcode9 from './simulator-xcode-9';
 import { exec } from 'teen_process';
 
 
+// https://regex101.com/r/MEL55t/1
+const WEBINSPECTOR_SOCKET_REGEXP = /\s+(\S+com\.apple\.webinspectord_sim\.socket)/;
+
 class SimulatorXcode93 extends SimulatorXcode9 {
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
@@ -9,6 +12,9 @@ class SimulatorXcode93 extends SimulatorXcode9 {
     this.webInspectorSocket = null;
   }
 
+  /*
+   * @override
+   */
   async getWebInspectorSocket () {
     if (this.webInspectorSocket) {
       return this.webInspectorSocket;
@@ -31,16 +37,15 @@ class SimulatorXcode93 extends SimulatorXcode9 {
       if (!record.includes(this.udid)) {
         continue;
       }
-      // console.log('we got the record for the udid');
-      // console.log(record);
-      // https://regex101.com/r/MEL55t/1
-      const match = /\s+(\S+com\.apple\.webinspectord_sim\.socket)/.exec(record);
+      const match = WEBINSPECTOR_SOCKET_REGEXP.exec(record);
       if (!match) {
         return null;
       }
       this.webInspectorSocket = match[1];
       return this.webInspectorSocket;
     }
+
+    return null;
   }
 }
 

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -299,7 +299,6 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       end tell
     `);
   }
-
 }
 
 export default SimulatorXcode9;

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -3,6 +3,7 @@ import SimulatorXcode7 from './simulator-xcode-7';
 import SimulatorXcode73 from './simulator-xcode-7.3';
 import SimulatorXcode8 from './simulator-xcode-8';
 import SimulatorXcode9 from './simulator-xcode-9';
+import SimulatorXcode93 from './simulator-xcode-9.3';
 import { simExists } from './utils';
 import xcode from 'appium-xcode';
 import log from './logger';
@@ -50,7 +51,11 @@ async function getSimulator (udid) {
   } else if (xcodeVersion.major === 8) {
     return new SimulatorXcode8(udid, xcodeVersion);
   } else if (xcodeVersion.major === 9) {
-    return new SimulatorXcode9(udid, xcodeVersion);
+    if (xcodeVersion.minor < 3) {
+      return new SimulatorXcode9(udid, xcodeVersion);
+    } else {
+      return new SimulatorXcode93(udid, xcodeVersion);
+    }
   }
 }
 


### PR DESCRIPTION
In the first step of providing support for iOS 11.3 web, we need to find the unix domain socket for the simulator.

I've searched _ever_ file on my machine while a sim is running, and can find no reference to the correct socket. The best solution I've come up with is ot use `lsof` and hope that the grouping together of entires for each sim (this works in my experimentation).