### PR TITLE
Add faceId biometrics

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -891,7 +891,7 @@ class SimulatorXcode6 extends EventEmitter {
       } catch (err) {
         log.errorAndThrow(`Could not complete operation. Make sure Simulator UI is running and the parent Appium application (e. g. Appium.app or Terminal.app) ` +
                           `is present in System Preferences > Security & Privacy > Privacy > Accessibility list. If the operation is still unsuccessful then ` +
-                          `it is not supported by this Simulator` +
+                          `it is not supported by this Simulator. ` +
                           `Original error: ${err.message}`);
       }
     });

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -901,7 +901,7 @@ class SimulatorXcode6 extends EventEmitter {
    *
    * @return {boolean} True if Touch ID Enrollment menu item is checked in Simulator menu
    */
-  async isTouchIDEnrolled () {
+  async isBiometricEnrolled () {
     const output = await this.executeUIClientScript(`
       tell application "System Events"
         tell process "Simulator"
@@ -919,7 +919,7 @@ class SimulatorXcode6 extends EventEmitter {
    *
    * @param {boolean} isEnabled - Set it to false in order to uncheck 'Toggle Enrolled State' flag
    */
-  async enrollTouchID (isEnabled = true) {
+  async enrollBiometric (isEnabled = true) {
     await this.executeUIClientScript(`
       tell application "System Events"
         tell process "Simulator"

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -889,8 +889,9 @@ class SimulatorXcode6 extends EventEmitter {
         const {stdout} = await exec('osascript', ['-e', resultScript]);
         return stdout;
       } catch (err) {
-        log.errorAndThrow(`Make sure Simulator UI is running and the parent Appium application (e. g. Appium.app or Terminal.app) ` +
-                          `is present in System Preferences > Security & Privacy > Privacy > Accessibility list. ` +
+        log.errorAndThrow(`Could not complete operation. Make sure Simulator UI is running and the parent Appium application (e. g. Appium.app or Terminal.app) ` +
+                          `is present in System Preferences > Security & Privacy > Privacy > Accessibility list. If the operation is still unsuccessful then it` +
+                          `it is not supported by this Simulator` +
                           `Original error: ${err.message}`);
       }
     });

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -890,7 +890,7 @@ class SimulatorXcode6 extends EventEmitter {
         return stdout;
       } catch (err) {
         log.errorAndThrow(`Could not complete operation. Make sure Simulator UI is running and the parent Appium application (e. g. Appium.app or Terminal.app) ` +
-                          `is present in System Preferences > Security & Privacy > Privacy > Accessibility list. If the operation is still unsuccessful then it` +
+                          `is present in System Preferences > Security & Privacy > Privacy > Accessibility list. If the operation is still unsuccessful then ` +
                           `it is not supported by this Simulator` +
                           `Original error: ${err.message}`);
       }

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -12,6 +12,15 @@ const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
 const startupLock = new AsyncLock();
 const preferencesPlistGuard = new AsyncLock();
 
+const BIOMETRICS = {
+  touchId: {
+    menuName: 'Touch Id'
+  },
+  faceId: {
+    menuName: 'Face Id',
+  }
+};
+
 class SimulatorXcode9 extends SimulatorXcode8 {
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
@@ -272,31 +281,40 @@ class SimulatorXcode9 extends SimulatorXcode8 {
   }
 
   /**
-   * Get the current state of Touch ID Enrollment feature.
+   * Get the current state of a biometric (touch id, face id) enrollment.
    * @override
    */
-  async isTouchIDEnrolled () {
+  async isBiometricEnrolled (biometricName='touchId') {
+    if (!BIOMETRICS[biometricName]) {
+      throw new Error(`${biometricName} is not a valid biometric. Use one of: ${JSON.stringify(_.keys(BIOMETRICS))}`);
+    }
+    const {menuName} = BIOMETRICS[biometricName];
     const output = await this.executeUIClientScript(`
       tell application "System Events"
         tell process "Simulator"
-          set dstMenuItem to menu item "Enrolled" of menu 1 of menu item "Touch ID" of menu 1 of menu bar item "Hardware" of menu bar 1
+          set dstMenuItem to menu item "Enrolled" of menu 1 of menu item "${menuName}" of menu 1 of menu bar item "Hardware" of menu bar 1
           set isChecked to (value of attribute "AXMenuItemMarkChar" of dstMenuItem) is "✓"
         end tell
       end tell
     `);
-    log.debug(`Touch ID enrolled state: ${output}`);
+    log.debug(`${menuName} enrolled state: ${output}`);
+
     return _.isString(output) && output.trim() === 'true';
   }
 
   /**
-   * Execute a special Apple script, which changes Touch ID feature testing in Simulator UI client.
+   * Execute a special Apple script, which enrolls biometric (TouchId, FaceId) feature testing in Simulator UI client.
    * @override
    */
-  async enrollTouchID (isEnabled = true) {
+  async enrollBiometric (isEnabled = true, biometricName='touchId') {
+    if (!BIOMETRICS[biometricName]) {
+      throw new Error(`${biometricName} is not a valid biometric. Use one of: ${JSON.stringify(_.keys(BIOMETRICS))}`);
+    }
+    const {menuName} = BIOMETRICS[biometricName];
     await this.executeUIClientScript(`
       tell application "System Events"
         tell process "Simulator"
-          set dstMenuItem to menu item "Enrolled" of menu 1 of menu item "Touch ID" of menu 1 of menu bar item "Hardware" of menu bar 1
+          set dstMenuItem to menu item "Enrolled" of menu 1 of menu item "${menuName}" of menu 1 of menu bar item "Hardware" of menu bar 1
           set isChecked to (value of attribute "AXMenuItemMarkChar" of dstMenuItem) is "✓"
           if ${isEnabled ? 'not ' : ''}isChecked then
             click dstMenuItem

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -12,19 +12,21 @@ const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
 const startupLock = new AsyncLock();
 const preferencesPlistGuard = new AsyncLock();
 
-const BIOMETRICS = {
-  touchId: {
-    menuName: 'Touch Id'
-  },
-  faceId: {
-    menuName: 'Face Id',
-  }
-};
+
 
 class SimulatorXcode9 extends SimulatorXcode8 {
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
   }
+
+  static BIOMETRICS = {
+    touchId: {
+      menuName: 'Touch Id'
+    },
+    faceId: {
+      menuName: 'Face Id',
+    }
+  };
 
   /**
    * @typedef {Object} DevicePreferences
@@ -280,15 +282,20 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     `;
   }
 
+  getBiometric (biometricName) {
+    const {BIOMETRICS} = SimulatorXcode9;
+    if (!BIOMETRICS[biometricName]) {
+      throw new Error(`${biometricName} is not a valid biometric. Use one of: ${JSON.stringify(_.keys(BIOMETRICS))}`);
+    }
+    return BIOMETRICS[biometricName];
+  }
+
   /**
    * Get the current state of a biometric (touch id, face id) enrollment.
    * @override
    */
-  async isBiometricEnrolled (biometricName='touchId') {
-    if (!BIOMETRICS[biometricName]) {
-      throw new Error(`${biometricName} is not a valid biometric. Use one of: ${JSON.stringify(_.keys(BIOMETRICS))}`);
-    }
-    const {menuName} = BIOMETRICS[biometricName];
+  async isBiometricEnrolled (biometricName=SimulatorXcode9.BIOMETRICS.touchId) {
+    const {menuName} = this.getBiometric(biometricName);
     const output = await this.executeUIClientScript(`
       tell application "System Events"
         tell process "Simulator"
@@ -306,11 +313,8 @@ class SimulatorXcode9 extends SimulatorXcode8 {
    * Execute a special Apple script, which enrolls biometric (TouchId, FaceId) feature testing in Simulator UI client.
    * @override
    */
-  async enrollBiometric (isEnabled = true, biometricName='touchId') {
-    if (!BIOMETRICS[biometricName]) {
-      throw new Error(`${biometricName} is not a valid biometric. Use one of: ${JSON.stringify(_.keys(BIOMETRICS))}`);
-    }
-    const {menuName} = BIOMETRICS[biometricName];
+  async enrollBiometric (isEnabled = true, biometricName=SimulatorXcode9.BIOMETRICS.touchId) {
+    const {menuName} = this.getBiometric(biometricName);
     await this.executeUIClientScript(`
       tell application "System Events"
         tell process "Simulator"

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -363,8 +363,12 @@ function runTests (deviceType) {
         if (process.env.TRAVIS) {
           this.skip();
         }
-        await sim.enrollBiometric(true, biometric);
-        (await sim.isBiometricEnrolled(biometric)).should.be.true;
+        try {
+          await sim.enrollBiometric(true, biometric);
+          (await sim.isBiometricEnrolled(biometric)).should.be.true;
+        } catch (e) {
+          e.message.should.match(/not supported/);
+        }
       });
 
       it(`should properly enroll ${biometric} to disabled state`, async function () {
@@ -373,8 +377,12 @@ function runTests (deviceType) {
         if (process.env.TRAVIS) {
           this.skip();
         }
-        await sim.enrollBiometric(false, biometric);
-        (await sim.isBiometricEnrolled(biometric)).should.be.false;
+        try {
+          await sim.enrollBiometric(false, biometric);
+          (await sim.isBiometricEnrolled(biometric)).should.be.false;
+        } catch (e) {
+          e.message.should.match(/not supported/);
+        }
       });
     }
   });

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -532,7 +532,7 @@ let deviceTypes;
 if (!process.env.TRAVIS && !process.env.DEVICE) {
   console.log('Not on TRAVIS, testing all versions'); // eslint-disable-line no-console
   deviceTypes = [
-    /*{
+    {
       version: '9.2',
       device: 'iPhone 6s'
     },
@@ -559,7 +559,7 @@ if (!process.env.TRAVIS && !process.env.DEVICE) {
     {
       version: '11.3',
       device: 'iPhone 6s'
-    },*/
+    },
     {
       version: '11.4',
       device: 'iPhone X'

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -325,7 +325,7 @@ function runTests (deviceType) {
     });
   });
 
-  describe('touch ID enrollment', async function () {
+  describe('biometric (touch Id, face Id) enrollment', async function () {
     let sim;
     this.timeout(LONG_TIMEOUT);
 
@@ -343,37 +343,40 @@ function runTests (deviceType) {
       await killAllSimulators();
       await deleteSimulator(sim.udid, deviceType.version);
     });
+    const biometrics = ['touchId', 'faceId'];
 
-    // FIXME: Remove this test after Appium's parent process has accessibility permissions
-    // on Travis
-    it('should fail if cannot enroll Touch ID', async function () {
-      if (!process.env.TRAVIS) {
-        this.skip();
-      }
-      const errorPattern = /is present in System Preferences/;
-      await sim.enrollTouchID().should.eventually.be.rejectedWith(errorPattern);
-      await sim.isTouchIDEnrolled().should.eventually.be.rejectedWith(errorPattern);
-    });
-
-    it('should properly enroll Touch ID to enabled state', async function () {
-      // FIXME: Remove this condition after Appium's parent process has accessibility permissions
+    for (let biometric of biometrics) {
+      // FIXME: Remove this test after Appium's parent process has accessibility permissions
       // on Travis
-      if (process.env.TRAVIS) {
-        this.skip();
-      }
-      await sim.enrollTouchID();
-      (await sim.isTouchIDEnrolled()).should.be.true;
-    });
+      it(`should fail if cannot enroll ${biometric}`, async function () {
+        if (!process.env.TRAVIS) {
+          this.skip();
+        }
+        const errorPattern = /is present in System Preferences/;
+        await sim.enrollBiometric(true, biometric).should.eventually.be.rejectedWith(errorPattern);
+        await sim.isBiometricEnrolled(biometric).should.eventually.be.rejectedWith(errorPattern);
+      });
 
-    it('should properly enroll Touch ID to disabled state', async function () {
-      // FIXME: Remove this condition after Appium's parent process has accessibility permissions
-      // on Travis
-      if (process.env.TRAVIS) {
-        this.skip();
-      }
-      await sim.enrollTouchID(false);
-      (await sim.isTouchIDEnrolled()).should.be.false;
-    });
+      it(`should properly enroll ${biometric} to enabled state`, async function () {
+        // FIXME: Remove this condition after Appium's parent process has accessibility permissions
+        // on Travis
+        if (process.env.TRAVIS) {
+          this.skip();
+        }
+        await sim.enrollBiometric(true, biometric);
+        (await sim.isBiometricEnrolled(biometric)).should.be.true;
+      });
+
+      it(`should properly enroll ${biometric} to disabled state`, async function () {
+        // FIXME: Remove this condition after Appium's parent process has accessibility permissions
+        // on Travis
+        if (process.env.TRAVIS) {
+          this.skip();
+        }
+        await sim.enrollBiometric(false, biometric);
+        (await sim.isBiometricEnrolled(biometric)).should.be.false;
+      });
+    }
   });
 
 
@@ -521,7 +524,7 @@ let deviceTypes;
 if (!process.env.TRAVIS && !process.env.DEVICE) {
   console.log('Not on TRAVIS, testing all versions'); // eslint-disable-line no-console
   deviceTypes = [
-    {
+    /*{
       version: '9.2',
       device: 'iPhone 6s'
     },
@@ -548,6 +551,10 @@ if (!process.env.TRAVIS && !process.env.DEVICE) {
     {
       version: '11.3',
       device: 'iPhone 6s'
+    },*/
+    {
+      version: '11.4',
+      device: 'iPhone X'
     }
   ];
 } else {


### PR DESCRIPTION
* Went in to fix IOS Simulator because tests were failing for touchId on iPhone X (because iPhone X doesn't support touchId)
* Went ahead and added `faceId` as a biometric that can also be used alongside `touchId` since it's something that has been asked for and probably will be in high demand
* Updated tests to test both and also updated tests to catch exceptions
* Will update `appium-xcuitest-driver` next to use the new interface