### PR TITLE
Set simulator window to be rotated automatically when asked

### DIFF
--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -77,7 +77,11 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     if (opts.scaleFactor) {
       opts.devicePreferences.SimulatorWindowLastScale = parseFloat(opts.scaleFactor);
     }
-    const commonPreferences = {};
+    // This option is necessary to make the Simulator window follow
+    // the actual XCUIDevice orientation
+    const commonPreferences = {
+      RotateWindowWhenSignaledByGuest: true
+    };
     if (_.isBoolean(opts.connectHardwareKeyboard)) {
       opts.devicePreferences.ConnectHardwareKeyboard = opts.connectHardwareKeyboard;
       commonPreferences.ConnectHardwareKeyboard = opts.connectHardwareKeyboard;


### PR DESCRIPTION
We've finally got a response from Apple and they suggested to enable Hardware->Rotate Device Automatically Simulator option in order for its window to follow the actual screen orientation set on XCUIDevice instance.