### PR TITLE
Update Travis config to use Xcode 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,16 @@ matrix:
     - osx_image: xcode8.3
       env: DEVICE=10.3
 
-    - osx_image: xcode9.2
+    - osx_image: xcode9.3
       env: DEVICE=10.3
-    - osx_image: xcode9.2
-      env: DEVICE=11.2
-
-    - osx_image: xcode9.3beta
-      env: DEVICE=10.3
-    - osx_image: xcode9.3beta
+    - osx_image: xcode9.3
       env: DEVICE=11.3
 
+    # TODO: uncomment once Travis 9.4 VMs have iOS 11.3 SDK installed
+    # - osx_image: xcode9.4
+    #   env: DEVICE=11.3
+    - osx_image: xcode9.4
+      env: DEVICE=11.4
 script:
   - npm test && _FORCE_LOGS=1 npm run mocha -- -R spec build/test/**/*-e2e-specs.js
 after_success:


### PR DESCRIPTION
Adjust the config to support Xcode 9.4. Right now we cannot run iOS < 11.4 on Xcode 9.4 because those VMs do not have the SDKs installed. They are aware of this fact.