### PR TITLE
fix getting biometric

### DIFF
--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -286,22 +286,24 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     `;
   }
 
+  /**
+   * Return proper biometric menu name object.
+   * @param {string} biometricName A key in BIOMETRICS like 'bundleId'
+   * @returns {object} Object in BIOMETRICS
+   */
   getBiometric (biometricName) {
     const {BIOMETRICS} = SimulatorXcode9;
-    const bio = Object.keys(BIOMETRICS).filter(function (key) {
-      return BIOMETRICS[key].menuName === biometricName.menuName;
-    });
-    if (bio.length === 0) {
+    if (!BIOMETRICS[biometricName]) {
       throw new Error(`${biometricName} is not a valid biometric. Use one of: ${JSON.stringify(_.keys(BIOMETRICS))}`);
     }
-    return biometricName;
+    return BIOMETRICS[biometricName];
   }
 
   /**
    * Get the current state of a biometric (touch id, face id) enrollment.
    * @override
    */
-  async isBiometricEnrolled (biometricName=SimulatorXcode9.BIOMETRICS.touchId) {
+  async isBiometricEnrolled (biometricName = 'touchId') {
     const {menuName} = this.getBiometric(biometricName);
     const output = await this.executeUIClientScript(`
       tell application "System Events"
@@ -320,7 +322,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
    * Execute a special Apple script, which enrolls biometric (TouchId, FaceId) feature testing in Simulator UI client.
    * @override
    */
-  async enrollBiometric (isEnabled = true, biometricName=SimulatorXcode9.BIOMETRICS.touchId) {
+  async enrollBiometric (isEnabled = true, biometricName = 'touchId') {
     const {menuName} = this.getBiometric(biometricName);
     await this.executeUIClientScript(`
       tell application "System Events"

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -288,10 +288,13 @@ class SimulatorXcode9 extends SimulatorXcode8 {
 
   getBiometric (biometricName) {
     const {BIOMETRICS} = SimulatorXcode9;
-    if (!BIOMETRICS[biometricName]) {
+    const bio = Object.keys(BIOMETRICS).filter(function (key) {
+      return BIOMETRICS[key].menuName === biometricName.menuName;
+    });
+    if (bio.length === 0) {
       throw new Error(`${biometricName} is not a valid biometric. Use one of: ${JSON.stringify(_.keys(BIOMETRICS))}`);
     }
-    return BIOMETRICS[biometricName];
+    return biometricName;
   }
 
   /**

--- a/test/unit/simulator-xcode-9-specs.js
+++ b/test/unit/simulator-xcode-9-specs.js
@@ -1,0 +1,36 @@
+// transpile:mocha
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import SimulatorXcode9 from "../../lib/simulator-xcode-9";
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const XCODE_VERSION_9 = {
+  versionString: '9.0',
+  versionFloat: 9.0,
+  major: 9,
+  minor: 0,
+  patch: undefined
+};
+
+describe('SimulatorXcode9', function () {
+  let simulatorXcode9;
+
+  beforeEach(function () {
+    simulatorXcode9 = new SimulatorXcode9('1234', XCODE_VERSION_9);
+  });
+
+  describe('getBiometric', function () {
+    it('return touch id object', async function () {
+      simulatorXcode9.getBiometric('touchId').should.eql({ menuName: 'Touch Id' });
+    });
+
+    it('raise an error since the argument does not exist in biometric', async function () {
+      (function () {
+        simulatorXcode9.getBiometric('no-touchId');
+      }).should.throw(Error, 'no-touchId is not a valid biometric. Use one of: ["touchId","faceId"]');
+    });
+  });
+});


### PR DESCRIPTION
I encountered below error when I called touch id enrollment feature.

> @driver.toggle_touch_id_enrollment true
Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: [object Object] is not a valid biometric. Use one of: ["touchId","faceId"]
from UnknownError: An unknown server-side error occurred while processing the command. Original error: [object Object] is not a valid biometric. Use one of: ["touchId","faceId"]

- `biometricName` is `{menuName: "Touch id"}`
- `BIOMETRICS` is `{touchId: {menuName: "Touch id"}, faceId: {menuName: "Face id"}}`
- Hence, `BIOMETRICS[biometricName]` never be true

~~This PR fix the behaviour to make sure the `menuName` exists in `BIOMETRICS`.~~
Use 'touchId' instead of `SimulatorXcode9.BIOMETRICS.touchId`

~~In JS world, is there a good way to get key by `biometricName`?~~
I mean if `biometricName` can be `touchId`, not `{menuName: "Touch id"}`,  `BIOMETRICS[biometricName]` works properly. In the case, we need to change https://github.com/KazuCocoa/appium-ios-simulator/blob/476635a6ec67609337468176fbff24ade7f1dcf3/lib/simulator-xcode-9.js#L304 and https://github.com/KazuCocoa/appium-ios-simulator/blob/476635a6ec67609337468176fbff24ade7f1dcf3/lib/simulator-xcode-9.js#L323 .
