### PR TITLE
Fall back to non-AppleScript UI state detection if necessary permissions are missing

### DIFF
--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -44,14 +44,20 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    * @return {boolean} True of if UI client is running or false otherwise.
    */
   async isUIClientRunning () {
-    const args = ['-e', `tell application "System Events" to count processes whose bundle identifier is "${this.uiClientBundleId}"`];
-    const {stdout} = await exec('osascript', args);
-    const count = parseInt(stdout.trim(), 10);
-    if (isNaN(count)) {
-      log.errorAndThrow(`Cannot parse the count of running Simulator UI client instances from 'osascript ${args}' output: ${stdout}`);
+    try {
+      const args = ['-e', `tell application "System Events" to count processes whose bundle identifier is "${this.uiClientBundleId}"`];
+      const {stdout} = await exec('osascript', args);
+      const count = parseInt(stdout.trim(), 10);
+      if (isNaN(count)) {
+        throw new Error(`Cannot parse the count of running Simulator UI client instances from 'osascript ${args}' output: ${stdout}`);
+      }
+      log.debug(`The count of running Simulator UI client instances is ${count}`);
+      return count >= 1;
+    } catch (err) {
+      log.info(`Cannot retrieve Simulator UI state via Apple Script. Defaulting to pgrep. ` +
+        `Original error: ${err.message}`);
+      return await super.isUIClientRunning();
     }
-    log.debug(`The count of running Simulator UI client instances is ${count}`);
-    return count >= 1;
   }
 
   /**


### PR DESCRIPTION
It looks like Apple is getting super paranoid about security in Mojave-beta. This patch allows to avoid errors in UI state detection