### PR TITLE
Only update settings if necessary

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -61,27 +61,32 @@ async function plistPaths (sim, identifier) {
 }
 
 async function updateSettings (sim, plist, updates) {
-  let paths = await plistPaths(sim, plist);
-  for (let path of paths) {
-    await update(path, updates);
+  let updated = false;
+  for (let path of await plistPaths(sim, plist)) {
+    updated = await update(path, updates) || updated;
   }
+  return updated;
 }
 
 // update a plist file, located at pathToPlist
 // pass in an object, all settings specified in the object will be
 // updated on the plist, all others left as-is
 async function update (pathToPlist, updates) {
-  let currentSettings = await read(pathToPlist);
-  let newSettings = _.merge(currentSettings, updates);
-  await plist.updatePlistFile(pathToPlist, newSettings, true, false);
+  const currentSettings = await read(pathToPlist);
+  const newSettings = Object.assign({}, currentSettings, updates);
 
-  return newSettings;
+  if (_.isEqual(currentSettings, newSettings)) {
+    // no setting changes, so do nothing
+    return false;
+  }
+
+  await plist.updatePlistFile(pathToPlist, newSettings, true, false);
+  return true;
 }
 
 async function readSettings (sim, plist) {
   let settings = {};
-  let paths = await plistPaths(sim, plist);
-  for (let path of paths) {
+  for (let path of await plistPaths(sim, plist)) {
     settings[path] = await read(path);
   }
   return settings;
@@ -93,29 +98,29 @@ async function read (pathToPlist) {
 
 async function updateLocationSettings (sim, bundleId, authorized) {
   // update location cache
-  let newCachePrefs = {
+  const newCachePrefs = {
     LastFenceActivityTimestamp: 412122103.232983,
     CleanShutdown: true
   };
-  await updateSettings(sim, 'locationCache', {[bundleId]: newCachePrefs});
+  let updated = await updateSettings(sim, 'locationCache', {[bundleId]: newCachePrefs});
 
   // update location clients
-  let newClientPrefs = {
+  const newClientPrefs = {
     BundleId: bundleId,
     Authorized: !!authorized,
     Whitelisted: false,
   };
-  for (let file of await plistPaths(sim, 'locationClients')) {
+  for (const file of await plistPaths(sim, 'locationClients')) {
     log.debug(`Updating location client file: ${file}`);
 
     let updates = {};
 
     // see if the bundle is already there
-    let plist = await read(file);
+    const plist = await read(file);
 
     // random data that always seems to be in the clients.plist
-    let weirdLocKey = 'com.apple.locationd.bundle-/System/Library/' +
-                      'PrivateFrameworks/AOSNotification.framework';
+    const weirdLocKey = 'com.apple.locationd.bundle-/System/Library/' +
+                        'PrivateFrameworks/AOSNotification.framework';
     if (!_.has(plist, weirdLocKey)) {
       updates[weirdLocKey] = {
         BundlePath: '/System/Library/PrivateFrameworks/AOSNotification.framework',
@@ -126,13 +131,15 @@ async function updateLocationSettings (sim, bundleId, authorized) {
     }
 
     // create the update, and make sure it has sensible values
-    let baseSetting = _.has(plist, bundleId) ? plist[bundleId] : {};
+    const baseSetting = _.has(plist, bundleId) ? plist[bundleId] : {};
     updates[bundleId] = _.defaults(newClientPrefs, baseSetting);
     updates[bundleId].Executable = updates[bundleId].Executable || '';
     updates[bundleId].Registered = updates[bundleId].Registered || '';
 
-    await update(file, updates);
+    updated = await update(file, updates) || updated;
   }
+
+  return updated;
 }
 
 async function setReduceMotion (sim, reduceMotion = true) {
@@ -145,6 +152,8 @@ async function setReduceMotion (sim, reduceMotion = true) {
 }
 
 async function updateSafariUserSettings (sim, settingSet) {
+  log.debug('Updating Safari user settings');
+
   // add extra stuff to UserSettings.plist and EffectiveUserSettings.plist
   let newUserSettings = {};
   if (_.has(settingSet, 'WebKitJavaScriptEnabled')) {
@@ -156,25 +165,29 @@ async function updateSafariUserSettings (sim, settingSet) {
   if (_.has(settingSet, 'WarnAboutFraudulentWebsites')) {
     newUserSettings.safariForceFraudWarning = !settingSet.WarnAboutFraudulentWebsites;
   }
-  if (_.size(newUserSettings) > 0) {
-    log.debug('Updating Safari user settings');
-    let curUserSettings = await readSettings(sim, 'userSettings');
-    for (let [file, userSettingSet] of _.toPairs(curUserSettings)) {
-      // the user settings plist has two buckets, one for
-      // boolean settings (`restrictedBool`) and one for
-      // other value settings (`restrictedValue`). In each, the value
-      // is in a `value` sub-field.
-      if (!_.has(userSettingSet, 'restrictedBool')) {
-        userSettingSet.restrictedBool = {};
-      }
-      for (let [key, value] of _.toPairs(newUserSettings)) {
-        userSettingSet.restrictedBool[key] = {value};
-      }
 
-      // actually do the update
-      await update(file, userSettingSet);
-    }
+  if (_.size(newUserSettings) === 0) {
+    return false;
   }
+
+  let updated = false;
+  for (const [file, userSettingSet] of _.toPairs(await readSettings(sim, 'userSettings'))) {
+    // the user settings plist has two buckets, one for
+    // boolean settings (`restrictedBool`) and one for
+    // other value settings (`restrictedValue`). In each, the value
+    // is in a `value` sub-field.
+    if (!_.has(userSettingSet, 'restrictedBool')) {
+      userSettingSet.restrictedBool = {};
+    }
+    for (let [key, value] of _.toPairs(newUserSettings)) {
+      userSettingSet.restrictedBool[key] = {value};
+    }
+
+    // actually do the update
+    updated = await update(file, userSettingSet) || updated;
+  }
+
+  return updated;
 }
 
 async function updateLocale (sim, language, locale, calendarFormat) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -3,6 +3,7 @@ import { plist } from 'appium-support';
 import path from 'path';
 import log from './logger';
 import semver from 'semver';
+import B from 'bluebird';
 
 
 // returns path to plist based on id for plist.
@@ -61,11 +62,9 @@ async function plistPaths (sim, identifier) {
 }
 
 async function updateSettings (sim, plist, updates) {
-  let updated = false;
-  for (let path of await plistPaths(sim, plist)) {
-    updated = await update(path, updates) || updated;
-  }
-  return updated;
+  return await B.reduce(await plistPaths(sim, plist), async function reducer (updated, path) {
+    return await update(path, updates) || updated;
+  }, false);
 }
 
 // update a plist file, located at pathToPlist
@@ -166,7 +165,7 @@ async function updateSafariUserSettings (sim, settingSet) {
     newUserSettings.safariForceFraudWarning = !settingSet.WarnAboutFraudulentWebsites;
   }
 
-  if (_.size(newUserSettings) === 0) {
+  if (_.isEmpty(newUserSettings)) {
     return false;
   }
 

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -630,8 +630,9 @@ class SimulatorXcode6 extends EventEmitter {
    * @param {object} updates - The hash of key/value pairs to update for Safari.
    */
   async updateSafariSettings (updates) {
-    await settings.updateSafariUserSettings(this, updates);
-    await settings.updateSettings(this, 'mobileSafari', updates);
+    let updated = await settings.updateSafariUserSettings(this, updates);
+    updated = await settings.updateSettings(this, 'mobileSafari', updates) || updated;
+    return updated;
   }
 
   /**

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -631,8 +631,7 @@ class SimulatorXcode6 extends EventEmitter {
    */
   async updateSafariSettings (updates) {
     let updated = await settings.updateSafariUserSettings(this, updates);
-    updated = await settings.updateSettings(this, 'mobileSafari', updates) || updated;
-    return updated;
+    return await settings.updateSettings(this, 'mobileSafari', updates) || updated;
   }
 
   /**

--- a/test/unit/settings-specs.js
+++ b/test/unit/settings-specs.js
@@ -32,7 +32,7 @@ describe('settings', function () {
   });
 
   describe('general plist handling', function () {
-    const plist = path.resolve('test/assets/sample.plist');
+    const plist = path.resolve('test', 'assets', 'sample.plist');
     const expectedField = 'com.apple.locationd.bundle-/System/Library/PrivateFrameworks/Parsec.framework';
     let tmpPlist;
 
@@ -51,11 +51,24 @@ describe('settings', function () {
       let originalData = await settings.read(tmpPlist);
       originalData[expectedField]
         .Whitelisted = true;
-      await settings.update(tmpPlist, originalData);
-      let updatedData = await settings.read(tmpPlist);
+      let updated = await update(tmpPlist, originalData);
+      updated.should.be.true;
+      let updatedData = await read(tmpPlist);
 
       updatedData[expectedField]
         .Whitelisted.should.be.true;
+
+      originalData.should.eql(updatedData);
+    });
+
+    it('should return false when no changes are made', async function () {
+      let originalData = await read(tmpPlist);
+      let updated = await update(tmpPlist, originalData);
+      updated.should.be.false;
+      let updatedData = await read(tmpPlist);
+
+      updatedData[expectedField]
+        .Whitelisted.should.be.false;
 
       originalData.should.eql(updatedData);
     });

--- a/test/unit/settings-specs.js
+++ b/test/unit/settings-specs.js
@@ -51,9 +51,9 @@ describe('settings', function () {
       let originalData = await settings.read(tmpPlist);
       originalData[expectedField]
         .Whitelisted = true;
-      let updated = await update(tmpPlist, originalData);
+      let updated = await settings.update(tmpPlist, originalData);
       updated.should.be.true;
-      let updatedData = await read(tmpPlist);
+      let updatedData = await settings.read(tmpPlist);
 
       updatedData[expectedField]
         .Whitelisted.should.be.true;
@@ -62,10 +62,10 @@ describe('settings', function () {
     });
 
     it('should return false when no changes are made', async function () {
-      let originalData = await read(tmpPlist);
-      let updated = await update(tmpPlist, originalData);
+      let originalData = await settings.read(tmpPlist);
+      let updated = await settings.update(tmpPlist, originalData);
       updated.should.be.false;
-      let updatedData = await read(tmpPlist);
+      let updatedData = await settings.read(tmpPlist);
 
       updatedData[expectedField]
         .Whitelisted.should.be.false;


### PR DESCRIPTION
We have all the machinery in place to check if requested settings values are different from current values. This can be important since changed values means rebooting a simulator. Calling code will have to be updated to take the return value and either reboot or not, depending on need.