### PR TITLE
Move semver-compare to semver.lt

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -2,7 +2,8 @@ import _ from 'lodash';
 import { plist } from 'appium-support';
 import path from 'path';
 import log from './logger';
-import compare from 'semver-compare';
+import semver from 'semver';
+
 
 // returns path to plist based on id for plist.
 // these ids are appium terms
@@ -37,7 +38,7 @@ async function plistPaths (sim, identifier) {
       paths.push(path.resolve(simDirectory, 'Library', 'Preferences', 'com.apple.locationd.plist'));
       break;
     case 'userSettings':
-      if (compare(sim.xcodeVersion.versionString, '7.3') < 0) {
+      if (semver.lt(semver.coerce(sim.xcodeVersion.versionString), semver.coerce('7.3'))) {
         paths.push(path.resolve(simDirectory, 'Library', 'ConfigurationProfiles', 'UserSettings.plist'));
         paths.push(path.resolve(simDirectory, 'Library', 'ConfigurationProfiles', 'EffectiveUserSettings.plist'));
         paths.push(path.resolve(simDirectory, 'Library', 'ConfigurationProfiles', 'PublicInfo', 'PublicEffectiveUserSettings.plist'));

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "^4.2.1",
     "node-simctl": "^3.11.0",
     "openssl-wrapper": "^0.3.4",
-    "semver-compare": "^1.0.0",
+    "semver": "^5.5.0",
     "source-map-support": "^0.5.3",
     "teen_process": "^1.3.0"
   },


### PR DESCRIPTION
This is the only place in our dependency tree where [semver-compare](https://www.npmjs.com/package/semver-compare) is used:
```
$ npm ls semver-compare
appium@1.8.0-beta /Users/isaacmurchie/code/appium
└─┬ appium-ios-driver@2.8.0
  └─┬ appium-ios-simulator@3.2.0
    └── semver-compare@1.0.0
```

The functionality is easily duplicated using [semver](https://www.npmjs.com/package/semver), which is used all over:
```
$ npm ls semver                                                                                                                                                                                                            8.10.0
appium@1.8.0-beta /Users/isaacmurchie/code/appium
├─┬ appium-android-driver@3.4.0
│ ├─┬ appium-adb@6.15.2
│ │ └── semver@5.5.0  deduped
│ └─┬ appium-chromedriver@4.4.0
│   └── semver@5.5.0  deduped
├─┬ appium-gulp-plugins@2.4.1
│ ├─┬ istanbul@1.1.0-alpha.1
│ │ └─┬ istanbul-api@1.3.1
│ │   └─┬ istanbul-lib-instrument@1.10.1
│ │     └── semver@5.5.0  deduped
│ ├─┬ node-notifier@5.2.1
│ │ └── semver@5.5.0  deduped
│ └── semver@5.5.0  deduped
├─┬ appium-ios-driver@2.8.0
│ ├─┬ appium-ios-simulator@3.2.0
│ │ └─┬ fkill@5.3.0
│ │   └─┬ execa@0.10.0
│ │     └─┬ cross-spawn@6.0.5
│ │       └── semver@5.5.0  deduped
│ └─┬ appium-xcode@3.6.0
│   └── semver@5.5.0  deduped
├─┬ appium-selendroid-driver@1.11.0
│ └─┬ utf7@1.0.2
│   └── semver@5.3.0
├─┬ babel-preset-env@1.7.0
│ └── semver@5.5.0  deduped
├─┬ continuation-local-storage@3.2.1
│ └─┬ async-listener@0.6.9
│   └── semver@5.5.0  deduped
├─┬ eslint-plugin-import@2.13.0
│ └─┬ read-pkg-up@2.0.0
│   └─┬ read-pkg@2.0.0
│     └─┬ normalize-package-data@2.4.0
│       └── semver@5.5.0  deduped
├─┬ fsevents@1.2.4
│ └─┬ node-pre-gyp@0.10.0
│   └── semver@5.5.0
├─┬ gulp@3.9.1
│ └── semver@4.3.6
└── semver@5.5.0
```