### PR TITLE
Tune isUIClientRunning verification

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -85,7 +85,7 @@ class SimulatorXcode6 extends EventEmitter {
    *
    * @return {?string} The process ID or null if the UI client is not running
    */
-  async uiClientPid () {
+  async getUIClientPid () {
     let stdout;
     try {
       ({stdout} = await exec('osascript', [
@@ -100,11 +100,12 @@ class SimulatorXcode6 extends EventEmitter {
         return null;
       }
     }
-    if (!isNaN(parseInt(stdout, 10))) {
-      log.debug(`Retrieved Simulator's UI client PID: ${stdout.trim()}`);
-      return stdout.trim();
+    if (isNaN(parseInt(stdout, 10))) {
+      return null;
     }
-    return null;
+    stdout = stdout.trim();
+    log.debug(`Got Simulator UI client PID: ${stdout}`);
+    return stdout;
   }
 
   /**
@@ -113,7 +114,7 @@ class SimulatorXcode6 extends EventEmitter {
    * @return {boolean} True of if UI client is running or false otherwise.
    */
   async isUIClientRunning () {
-    return !_.isNull(await this.uiClientPid());
+    return !_.isNull(await this.getUIClientPid());
   }
 
   /**

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -100,7 +100,7 @@ class SimulatorXcode6 extends EventEmitter {
         return null;
       }
     }
-    if (!isNaN(stdout)) {
+    if (!isNaN(parseInt(stdout, 10))) {
       log.debug(`Retrieved Simulator's UI client PID: ${stdout.trim()}`);
       return stdout.trim();
     }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -20,6 +20,7 @@ const { EventEmitter } = events;
 const STARTUP_TIMEOUT = 60 * 1000;
 const EXTRA_STARTUP_TIME = 2000;
 const UI_CLIENT_ACCESS_GUARD = new AsyncLock();
+const UI_CLIENT_BUNDLE_ID = 'com.apple.iphonesimulator';
 
 /*
  * This event is emitted as soon as iOS Simulator
@@ -73,17 +74,46 @@ class SimulatorXcode6 extends EventEmitter {
   }
 
   /**
+   * @return {string} Bundle identifier of Simulator UI client.
+   */
+  get uiClientBundleId () {
+    return UI_CLIENT_BUNDLE_ID;
+  }
+
+  /**
+   * Retrieves the current process id of the UI client
+   *
+   * @return {?string} The process ID or null if the UI client is not running
+   */
+  async uiClientPid () {
+    let stdout;
+    try {
+      ({stdout} = await exec('osascript', [
+        '-e',
+        `tell application "System Events" to unix id of processes whose bundle identifier is "${this.uiClientBundleId}"`
+      ]));
+    } catch (e) {
+      // Retry with pgrep, since Apple Script usage might be blocked by the OS
+      try {
+        ({stdout} = await exec('pgrep', ['-xni', this.simulatorApp.split('.')[0]]));
+      } catch (e1) {
+        return null;
+      }
+    }
+    if (!isNaN(stdout)) {
+      log.debug(`Retrieved Simulator's UI client PID: ${stdout.trim()}`);
+      return stdout.trim();
+    }
+    return null;
+  }
+
+  /**
    * Check the state of Simulator UI client.
    *
    * @return {boolean} True of if UI client is running or false otherwise.
    */
   async isUIClientRunning () {
-    try {
-      await exec('pgrep', ['-x', this.simulatorApp.split('.')[0]]);
-      return true;
-    } catch (err) {
-      return false;
-    }
+    return !_.isNull(await this.uiClientPid());
   }
 
   /**

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -39,12 +39,12 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    * @throws {Error} If sending the signal to the client process fails
    */
   async killUIClient (force = false) {
-    const pid = await this.uiClientPid();
+    const pid = await this.getUIClientPid();
     if (!pid) {
       return false;
     }
 
-    log.debug(`Sending kill signal to Simulator UI client with PID ${pid}`);
+    log.debug(`Sending ${force ? 'forced ' : ''}kill signal to Simulator UI client with PID ${pid}`);
     try {
       await exec('kill', force ? ['-9', pid] : [pid]);
       return true;

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -12,7 +12,6 @@ const STARTUP_TIMEOUT = 120 * 1000;
 const SAFARI_STARTUP_TIMEOUT = 25 * 1000;
 const SPRINGBOARD_BUNDLE_ID = 'com.apple.springboard';
 const MOBILE_SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
-const UI_CLIENT_BUNDLE_ID = 'com.apple.iphonesimulator';
 const PROCESS_LAUNCH_OK_PATTERN = (bundleId) => new RegExp(`${bundleId.replace('.', '\\.')}:\\s+\\d+`);
 
 class SimulatorXcode8 extends SimulatorXcode7 {
@@ -31,52 +30,27 @@ class SimulatorXcode8 extends SimulatorXcode7 {
   }
 
   /**
-   * @return {string} Bundle identifier of Simulator UI client.
-   */
-  get uiClientBundleId () {
-    return UI_CLIENT_BUNDLE_ID;
-  }
-
-  /**
-   * Check the state of Simulator UI client.
-   * @Override
-   *
-   * @return {boolean} True of if UI client is running or false otherwise.
-   */
-  async isUIClientRunning () {
-    try {
-      const args = ['-e', `tell application "System Events" to count processes whose bundle identifier is "${this.uiClientBundleId}"`];
-      const {stdout} = await exec('osascript', args);
-      const count = parseInt(stdout.trim(), 10);
-      if (isNaN(count)) {
-        throw new Error(`Cannot parse the count of running Simulator UI client instances from 'osascript ${args}' output: ${stdout}`);
-      }
-      log.debug(`The count of running Simulator UI client instances is ${count}`);
-      return count >= 1;
-    } catch (err) {
-      log.info(`Cannot retrieve Simulator UI state via Apple Script. Defaulting to pgrep. ` +
-        `Original error: ${err.message}`);
-      return await super.isUIClientRunning();
-    }
-  }
-
-  /**
    * Kill the UI client if it is running.
    *
    * @param {boolean} force - Set it to true to send SIGKILL signal to Simulator process.
    *                          SIGTERM will be sent by default.
    * @return {boolean} True if the UI client was successfully killed or false
    *                   if it is not running.
+   * @throws {Error} If sending the signal to the client process fails
    */
   async killUIClient (force = false) {
-    const osascriptArgs = ['-e', `tell application "System Events" to unix id of processes whose bundle identifier is "${this.uiClientBundleId}"`];
-    const {stdout} = await exec('osascript', osascriptArgs);
-    if (!stdout.trim().length) {
+    const pid = await this.uiClientPid();
+    if (!pid) {
       return false;
     }
-    const killArgs = force ? ['-9', stdout.trim()] : [stdout.trim()];
-    await exec('kill', killArgs);
-    return true;
+
+    log.debug(`Sending kill signal to Simulator UI client with PID ${pid}`);
+    try {
+      await exec('kill', force ? ['-9', pid] : [pid]);
+      return true;
+    } catch (e) {
+      throw new Error(`Cannot kill the Simulator UI client. Original error: ${e.message}`);
+    }
   }
 
   /**

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -97,10 +97,14 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       }
     };
     const waitForShutdown = async () => {
-      await waitForCondition(async () => {
-        const {state} = await this.stat();
-        return state === 'Shutdown';
-      }, {waitMs: SIMULATOR_SHUTDOWN_TIMEOUT, intervalMs: 500});
+      try {
+        await waitForCondition(async () => {
+          const {state} = await this.stat();
+          return state === 'Shutdown';
+        }, {waitMs: SIMULATOR_SHUTDOWN_TIMEOUT, intervalMs: 500});
+      } catch (err) {
+        throw new Error(`Simulator is not in 'Shutdown' state after ${SIMULATOR_SHUTDOWN_TIMEOUT}ms`);
+      }
     };
     let shouldWaitForBoot = true;
     const startTime = process.hrtime();


### PR DESCRIPTION
Mac OS Mojave blocks Apple script execution without special permissions, so we must have a fallback there.