### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-*.log
-test
-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 os: osx
 language: node_js
-node_js: "6"
+node_js: "8"
 matrix:
   include:
     - osx_image: xcode7.3

--- a/lib/certificate.js
+++ b/lib/certificate.js
@@ -181,7 +181,7 @@ class TrustStore {
    * @param {string} subj
    */
   async getRecordCount (subj) {
-    let result =  (await execSQLiteQuery(await this.getDB(), `SELECT count(*) FROM tsettings WHERE subj = '?'`, subj)).stdout;
+    let result = (await execSQLiteQuery(await this.getDB(), `SELECT count(*) FROM tsettings WHERE subj = '?'`, subj)).stdout;
     return parseInt(result.split('=')[1], 10);
   }
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -242,5 +242,7 @@ async function stub () {
   return await plistPaths;
 }
 
-export { update, updateSettings, updateLocationSettings, setReduceMotion,
-        updateSafariUserSettings, updateLocale, read, readSettings, stub };
+export {
+  update, updateSettings, updateLocationSettings, setReduceMotion,
+  updateSafariUserSettings, updateLocale, read, readSettings, stub,
+};

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -914,7 +914,7 @@ class SimulatorXcode6 extends EventEmitter {
    *
    * @returns {string} the generated Apple Script snippet.
    */
-  async generateWindowActivationScript () {
+  async generateWindowActivationScript () { // eslint-disable-line require-await
     return `
       tell application "System Events"
         tell process "Simulator"
@@ -1178,8 +1178,8 @@ class SimulatorXcode6 extends EventEmitter {
     let configFix = CONFIG_FIX;
     if (configFix[iosDeviceString]) {
       iosDeviceString = configFix[iosDeviceString];
-      log.debug(`Fixing device. Changed from '${opts.deviceName}' `+
-                  `to '${iosDeviceString}'`);
+      log.debug(`Fixing device. Changed from '${opts.deviceName}' ` +
+                `to '${iosDeviceString}'`);
     }
 
     log.debug(`Final device string is '${iosDeviceString}'`);
@@ -1190,7 +1190,7 @@ class SimulatorXcode6 extends EventEmitter {
    * @return {?string} The full path to the simulator's WebInspector Unix Domain Socket
    *   or `null` if there is no socket.
    */
-  async getWebInspectorSocket () {
+  async getWebInspectorSocket () { // eslint-disable-line require-await
     // there is no WebInspector socket for this version of Xcode
     return null;
   }

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -178,7 +178,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
 
     if (!_.isUndefined(prefs.SimulatorWindowCenter)) {
       // https://regex101.com/r/2ZXOij/2
-      const verificationPattern = /\{\-?\d+(\.\d+)?,\-?\d+(\.\d+)?\}/;
+      const verificationPattern = /{-?\d+(\.\d+)?,-?\d+(\.\d+)?}/;
       if (!_.isString(prefs.SimulatorWindowCenter) || !verificationPattern.test(prefs.SimulatorWindowCenter)) {
         log.errorAndThrow(`SimulatorWindowCenter is expected to match "{floatXPosition,floatYPosition}" format (without spaces). ` +
           `'${prefs.SimulatorWindowCenter}' is assigned instead.`);

--- a/package.json
+++ b/package.json
@@ -22,12 +22,18 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "lib",
+    "build/index.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-support": "^2.4.0",
     "appium-xcode": "^3.1.0",
     "async-lock": "^1.0.0",
     "asyncbox": "^2.3.1",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
     "fkill": "^5.0.0",
     "lodash": "^4.2.1",
@@ -39,7 +45,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",
     "build": "gulp transpile",
@@ -56,21 +62,19 @@
     "precommit-test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.0",
-    "babel-eslint": "^7.1.1",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
     "colors": "^1.1.2",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "2.1.0",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.4.0",
-    "express": "^4.14.0",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
     "fs-extra": "^7.0.0",
-    "gulp": "^3.8.11",
-    "https": "^1.0.0",
+    "gulp": "^4.0.0",
     "inquirer": "^6.0.0",
     "ios-test-app": "^2.6.0",
     "mocha": "^5.0.1",
@@ -80,16 +84,11 @@
     "uuid": "^3.1.0"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
+    "ignore": []
+  },
+  "babel": {
+    "plugins": [
+      "@babel/plugin-proposal-class-properties"
     ]
   }
 }

--- a/test/assets/certificate-test-server/server.js
+++ b/test/assets/certificate-test-server/server.js
@@ -12,7 +12,7 @@ const pem = B.promisifyAll(require('pem'));
 
   // Create an HTTPS server with a randomly generated certificate
   let key = await pem.createPrivateKeyAsync();
-  let keys = await pem.createCertificateAsync({days:1, selfSigned: true, serviceKey: key.key});
+  let keys = await pem.createCertificateAsync({days: 1, selfSigned: true, serviceKey: key.key});
 
   let server = https.createServer({key: keys.serviceKey, cert: keys.certificate}, function (req, res) {
     res.end('If you are seeing this the certificate has been installed');

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -185,7 +185,7 @@ function runTests (deviceType) {
       let sim = await getSimulator(udid);
       await sim.delete();
       let numDevicesAfter = (await simctl.getDevices())[deviceType.version].length;
-      numDevicesAfter.should.equal(numDevices-1);
+      numDevicesAfter.should.equal(numDevices - 1);
     });
 
     let itText = 'should match a bundleId to its app directory on a used sim';
@@ -325,7 +325,7 @@ function runTests (deviceType) {
     });
   });
 
-  describe('biometric (touch Id, face Id) enrollment', async function () {
+  describe('biometric (touch Id, face Id) enrollment', function () {
     let sim;
     this.timeout(LONG_TIMEOUT);
 
@@ -388,7 +388,7 @@ function runTests (deviceType) {
   });
 
 
-  describe('keychains backup', async function () {
+  describe('keychains backup', function () {
     let sim;
     this.timeout(LONG_TIMEOUT);
 

--- a/test/unit/calendar-specs.js
+++ b/test/unit/calendar-specs.js
@@ -1,4 +1,4 @@
- // transpile:mocha
+// transpile:mocha
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/test/unit/certificate-specs.js
+++ b/test/unit/certificate-specs.js
@@ -23,7 +23,7 @@ let tempDirectory;
 describe('when using TrustStore class', function () {
 
   function getUUID () {
-    return uuid.v4().replace(/\-/g, '');
+    return uuid.v4().replace(/-/g, '');
   }
 
   beforeEach(async function () {

--- a/test/unit/settings-specs.js
+++ b/test/unit/settings-specs.js
@@ -257,7 +257,7 @@ describe('settings', function () {
     });
 
     async function getData () {
-      return asyncmap(realFiles, (file) => {
+      return await asyncmap(realFiles, (file) => {
         return settings.read(file);
       }, true);
     }
@@ -285,12 +285,12 @@ describe('settings', function () {
 
   describe('setReduceMotion', function () {
     let sim;
-    before(async function ()  {
+    before(function () {
       sim = new SimulatorXcode6();
       sinon.stub(settings, 'setReduceMotion');
     });
 
-    afterEach(async function () {
+    afterEach(function () {
       sinon.restore();
       sinon.stub(settings, 'setReduceMotion');
     });

--- a/test/unit/simulator-xcode-9-specs.js
+++ b/test/unit/simulator-xcode-9-specs.js
@@ -23,11 +23,11 @@ describe('SimulatorXcode9', function () {
   });
 
   describe('getBiometric', function () {
-    it('return touch id object', async function () {
+    it('return touch id object', function () {
       simulatorXcode9.getBiometric('touchId').should.eql({ menuName: 'Touch Id' });
     });
 
-    it('raise an error since the argument does not exist in biometric', async function () {
+    it('raise an error since the argument does not exist in biometric', function () {
       (function () {
         simulatorXcode9.getBiometric('no-touchId');
       }).should.throw(Error, 'no-touchId is not a valid biometric. Use one of: ["touchId","faceId"]');

--- a/test/unit/utils-specs.js
+++ b/test/unit/utils-specs.js
@@ -235,7 +235,7 @@ describe('Device preferences verification', function () {
     });
 
     it('should throw if incorrect', function () {
-      const invalidValues = ['',  null, 'portrait', 'bla', -1];
+      const invalidValues = ['', null, 'portrait', 'bla', -1];
       for (const invalidValue of invalidValues) {
         (() => sim.verifyDevicePreferences({
           SimulatorWindowOrientation: invalidValue
@@ -257,14 +257,12 @@ describe('Device preferences verification', function () {
     });
 
     it('should throw if incorrect', function () {
-      const invalidValues = ['',  null, 'bla', '0'];
+      const invalidValues = ['', null, 'bla', '0'];
       for (const invalidValue of invalidValues) {
         (() => sim.verifyDevicePreferences({
           SimulatorWindowRotationAngle: invalidValue
         })).should.throw(Error, /is expected to be a valid number/);
       }
     });
-
   });
-
 });


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.