### PR TITLE
Add ability to change log prefix depending on platform

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,18 @@
 import { logger } from 'appium-support';
+import _ from 'lodash';
 
-const log = logger.getLogger('iOSSim');
 
+let prefix = 'iOSSim';
+function setLoggingPlatform (platform) {
+  if (!_.isEmpty(platform)) {
+    prefix = `${platform}Sim`;
+  }
+}
+
+const log = logger.getLogger(function () {
+  return prefix;
+});
+
+
+export { log, setLoggingPlatform };
 export default log;

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -43,6 +43,7 @@ class SimulatorXcode6 extends EventEmitter {
    */
   constructor (udid, xcodeVersion) {
     super();
+
     this.udid = String(udid);
     this.xcodeVersion = xcodeVersion;
 

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -5,9 +5,9 @@ import SimulatorXcode8 from './simulator-xcode-8';
 import SimulatorXcode9 from './simulator-xcode-9';
 import SimulatorXcode93 from './simulator-xcode-9.3';
 import SimulatorXcode10 from './simulator-xcode-10';
-import { simExists } from './utils';
+import { getSimulatorInfo } from './utils';
 import xcode from 'appium-xcode';
-import log from './logger';
+import { log, setLoggingPlatform } from './logger';
 
 
 function handleUnsupportedXcode (xcodeVersion) {
@@ -28,13 +28,17 @@ function handleUnsupportedXcode (xcodeVersion) {
  * @return {object} Simulator object associated with the udid passed in.
  */
 async function getSimulator (udid) {
-  let xcodeVersion = await xcode.getVersion(true);
+  const xcodeVersion = await xcode.getVersion(true);
+  const simulatorInfo = await getSimulatorInfo(udid);
 
-  if (!await simExists(udid)) {
-    throw new Error(`No sim found with udid ${udid}`);
+  if (!simulatorInfo) {
+    throw new Error(`No sim found with udid '${udid}'`);
   }
 
-  log.info(`Constructing iOS simulator for Xcode version ${xcodeVersion.versionString} ` +
+  // make sure we have the right logging prefix
+  setLoggingPlatform(simulatorInfo.platform);
+
+  log.info(`Constructing ${simulatorInfo.platform || 'iOS'} simulator for Xcode version ${xcodeVersion.versionString} ` +
            `with udid '${udid}'`);
   let SimClass;
   switch (xcodeVersion.major) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -162,14 +162,10 @@ async function getSimulatorInfo (udid) {
   // see the README for github.com/appium/node-simctl for example output of getDevices()
   let devices = await getDevices();
 
-  devices = _.toPairs(devices).map((pair) => {
-    return pair[1];
-  }).reduce((a, b) => {
-    return a.concat(b);
-  }, []);
-  return _.find(devices, (sim) => {
-    return sim.udid === udid;
-  });
+  devices = _.toPairs(devices)
+    .map((pair) => pair[1])
+    .reduce((a, b) => a.concat(b), []);
+  return _.find(devices, (sim) => sim.udid === udid);
 }
 
 async function simExists (udid) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -158,7 +158,7 @@ async function endAllSimulatorDaemons () {
   log.debug('Finishing ending all simulator daemons');
 }
 
-async function simExists (udid) {
+async function getSimulatorInfo (udid) {
   // see the README for github.com/appium/node-simctl for example output of getDevices()
   let devices = await getDevices();
 
@@ -167,9 +167,13 @@ async function simExists (udid) {
   }).reduce((a, b) => {
     return a.concat(b);
   }, []);
-  return !!_.find(devices, (sim) => {
+  return _.find(devices, (sim) => {
     return sim.udid === udid;
   });
+}
+
+async function simExists (udid) {
+  return !!(await getSimulatorInfo(udid));
 }
 
 async function safeRimRaf (delPath, tryNum = 0) {
@@ -300,6 +304,7 @@ export {
   endAllSimulatorDaemons,
   safeRimRaf,
   simExists,
+  getSimulatorInfo,
   installSSLCert,
   uninstallSSLCert,
   hasSSLCert,

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "mocha": "^5.0.1",
     "pem": "^1.8.3",
     "pre-commit": "^1.1.3",
-    "sinon": "^6.0.0",
+    "sinon": "^7.0.0",
     "uuid": "^3.1.0"
   },
   "greenkeeper": {

--- a/test/unit/calendar-specs.js
+++ b/test/unit/calendar-specs.js
@@ -9,13 +9,13 @@ import { execSQLiteQuery } from '../../lib/utils';
 
 chai.should();
 chai.use(chaiAsPromised);
-let expect = chai.expect;
+const expect = chai.expect;
 
-let cwd = process.cwd();
-let assetsDir = `${cwd}/test/assets`;
-let tccDir = `${assetsDir}/Library/TCC`;
-let tccDirOriginal = `${assetsDir}/Library/TCC-Original`;
-let bundleID = 'com.fake.bundleid';
+const cwd = process.cwd();
+const assetsDir = `${cwd}/test/assets`;
+const tccDir = `${assetsDir}/Library/TCC`;
+const tccDirOriginal = `${assetsDir}/Library/TCC-Original`;
+const bundleID = 'com.fake.bundleid';
 
 describe('Calendar.js', function () {
   let calendar;

--- a/test/unit/certificate-specs.js
+++ b/test/unit/certificate-specs.js
@@ -9,11 +9,11 @@ import uuid from 'uuid';
 
 chai.should();
 chai.use(chaiAsPromised);
-let expect = chai.expect;
+const expect = chai.expect;
 
-let cwd = process.cwd();
-let assetsDir = `${cwd}/test/assets`;
-let keychainsDir = `${assetsDir}/Library/Keychains`;
+const cwd = process.cwd();
+const assetsDir = `${cwd}/test/assets`;
+const keychainsDir = `${assetsDir}/Library/Keychains`;
 let keychainsDirOriginal;
 let certificate;
 let trustStore;

--- a/test/unit/isolate-sim-specs.js
+++ b/test/unit/isolate-sim-specs.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import * as nodeSimctl from 'node-simctl';
 import { devices } from '../assets/deviceList';
 import { getAllUdids } from '../../lib/extensions/isolate-sim.js';
-import Promise from 'bluebird';
+import B from 'bluebird';
 
 
 chai.should();
@@ -18,7 +18,7 @@ describe('isolate sims', function () {
 
   beforeEach(function () {
     getDevicesStub = sinon.stub(nodeSimctl, 'getDevices');
-    getDevicesStub.returns(Promise.resolve(devices));
+    getDevicesStub.returns(B.resolve(devices));
   });
   afterEach(function () {
     nodeSimctl.getDevices.restore();

--- a/test/unit/simulator-common-specs.js
+++ b/test/unit/simulator-common-specs.js
@@ -7,7 +7,7 @@ import chaiAsPromised from 'chai-as-promised';
 import _ from 'lodash';
 import sinon from 'sinon';
 import { fs } from 'appium-support';
-import Promise from 'bluebird';
+import B from 'bluebird';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -33,7 +33,7 @@ for (let [name, simClass] of _.toPairs(simulatorClasses)) {
     });
 
     it('should return an array for getAppDirs()', async function () {
-      let stub = sinon.stub(sim, 'getAppDir').returns(Promise.resolve(['/App/Path/']));
+      let stub = sinon.stub(sim, 'getAppDir').returns(B.resolve(['/App/Path/']));
       sim._platformVersion = 9.1;
       let dirs = await sim.getAppDirs('test');
       dirs.should.have.length(2);
@@ -52,26 +52,26 @@ for (let [name, simClass] of _.toPairs(simulatorClasses)) {
         sandbox.restore();
       });
       it('should not delete anything if no directories are found', async function () {
-        sandbox.stub(sim, 'getPlatformVersion').returns(Promise.resolve(7.1));
-        sandbox.stub(sim, 'getAppDir').returns(Promise.resolve());
+        sandbox.stub(sim, 'getPlatformVersion').returns(B.resolve(7.1));
+        sandbox.stub(sim, 'getAppDir').returns(B.resolve());
         await sim.cleanCustomApp('someApp', 'com.some.app');
         sinon.assert.notCalled(fs.rimraf);
       });
       it('should delete app directories', async function () {
-        sandbox.stub(sim, 'getPlatformVersion').returns(Promise.resolve(7.1));
-        sandbox.stub(sim, 'getAppDirs').returns(Promise.resolve(['/some/path', '/another/path']));
+        sandbox.stub(sim, 'getPlatformVersion').returns(B.resolve(7.1));
+        sandbox.stub(sim, 'getAppDirs').returns(B.resolve(['/some/path', '/another/path']));
         await sim.cleanCustomApp('someApp', 'com.some.app');
         sinon.assert.called(fs.rimraf);
       });
       it('should delete plist file for iOS8+', async function () {
-        sandbox.stub(sim, 'getPlatformVersion').returns(Promise.resolve(9));
-        sandbox.stub(sim, 'getAppDirs').returns(Promise.resolve(['/some/path', '/another/path']));
+        sandbox.stub(sim, 'getPlatformVersion').returns(B.resolve(9));
+        sandbox.stub(sim, 'getAppDirs').returns(B.resolve(['/some/path', '/another/path']));
         await sim.cleanCustomApp('someApp', appBundleId);
         sinon.assert.calledWithMatch(fs.rimraf, /plist/);
       });
       it('should not delete plist file for iOS7.1', async function () {
-        sandbox.stub(sim, 'getPlatformVersion').returns(Promise.resolve(7.1));
-        sandbox.stub(sim, 'getAppDirs').returns(Promise.resolve(['/some/path', '/another/path']));
+        sandbox.stub(sim, 'getPlatformVersion').returns(B.resolve(7.1));
+        sandbox.stub(sim, 'getAppDirs').returns(B.resolve(['/some/path', '/another/path']));
         await sim.cleanCustomApp('someApp', appBundleId);
         sinon.assert.neverCalledWithMatch(fs.rimraf, /plist/);
       });


### PR DESCRIPTION
Updating logging so the prefix is changed depending on the platform. This will not work if there are multiple simulators of different platforms (since the logger is shared) but that bridge can be crossed if/when it is reached.

Logs become like:
```
info tvOSSim Constructing tvOS simulator for Xcode version 9.4.1 with udid 'C2DEBF4F-D7D4-4A3F-8A31-13E86B505B1B'
info iOSSim Constructing iOS simulator for Xcode version 9.4.1 with udid '697D0C48-A7E6-4BBC-9112-015BE58D9432'
info watchOSSim Constructing watchOS simulator for Xcode version 9.4.1 with udid '861897A6-9E93-4423-9D5E-8D9FCDD84611'
```