### PR TITLE
Handle errant minimum value

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -179,8 +179,16 @@ async function updateSafariUserSettings (sim, settingSet) {
     if (!_.has(userSettingSet, 'restrictedBool')) {
       userSettingSet.restrictedBool = {};
     }
-    for (let [key, value] of _.toPairs(newUserSettings)) {
+    for (const [key, value] of _.toPairs(newUserSettings)) {
       userSettingSet.restrictedBool[key] = {value};
+    }
+
+    // ensure that BigInt `-1` values become regular -1, so the plist creator does not fail
+    const restrictedValues = userSettingSet.restrictedValue || {};
+    for (const [key, value] of _.toPairs(restrictedValues)) {
+      if (value.rangeMinimum && value.rangeMinimum.value === 18446744073709551615n) {
+        restrictedValues[key].rangeMinimum = -1;
+      }
     }
 
     // actually do the update

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   ],
   "devDependencies": {
     "ajv": "^6.5.3",
-    "appium-gulp-plugins": "^4.0.0",
+    "appium-gulp-plugins": "^4.1.0",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
     "colors": "^1.1.2",


### PR DESCRIPTION
In some cases the Safari plist gets a minimum value of -1 that gets encoded as an unsigned long, and the plist creator fails (taken from https://travis-ci.org/appium/appium-xcuitest-driver/jobs/531603055#L1394-L1413):
```
dbug iOSSim Updating Safari user settings
ERR! iOS Error setting safari preferences, prefs will not work
ERR! iOS Error: unhandled entry: 18446744073709551615
ERR! iOS     at toEntries (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:376:11)
ERR! iOS     at /Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:415:22
ERR! iOS     at Array.forEach (<anonymous>)
ERR! iOS     at toEntriesObject (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:414:21)
ERR! iOS     at toEntries (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:352:14)
ERR! iOS     at /Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:415:22
ERR! iOS     at Array.forEach (<anonymous>)
ERR! iOS     at toEntriesObject (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:414:21)
ERR! iOS     at toEntries (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:352:14)
ERR! iOS     at /Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:415:22
ERR! iOS     at Array.forEach (<anonymous>)
ERR! iOS     at toEntriesObject (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:414:21)
ERR! iOS     at toEntries (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:352:14)
ERR! iOS     at /Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:415:22
ERR! iOS     at Array.forEach (<anonymous>)
ERR! iOS     at toEntriesObject (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:414:21)
ERR! iOS     at toEntries (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:352:14)
ERR! iOS     at module.exports (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/bplist-creator/bplistCreator.js:25:17)
ERR! iOS     at Object.updatePlistFile (/Users/travis/build/appium/appium-xcuitest-driver/node_modules/appium-support/lib/plist.js:61:27)
```