### PR TITLE
Fix geolocation coordinates format

### DIFF
--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -294,9 +294,9 @@ class SimulatorXcode8 extends SimulatorXcode7 {
           set dstMenuItem to menu item (featureName & "…") of menu 1 of menu item "Location" of menu 1 of menu bar item "Debug" of menu bar 1
           click dstMenuItem
           delay 1
-          set value of text field 1 of window featureName to "${latitude}"
+          set value of text field 1 of window featureName to ${latitude} as string
           delay 0.5
-          set value of text field 2 of window featureName to "${longitude}"
+          set value of text field 2 of window featureName to ${longitude} as string
           delay 0.5
           click button "OK" of window featureName
           delay 0.5


### PR DESCRIPTION
Number formatting depends on System preferences and Locale.
Issues occurs if user is using commas as decimal separator.
As string formatting should fix this problem.