### PR TITLE
fix: get tests to run on xcode 11 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,16 @@ matrix:
 
     - osx_image: xcode10.2
       env: DEVICE=12.2
+
+    - osx_image: xcode11
+      env: DEVICE=13.0
+install:
+  - npm install
+  - if [ ${TRAVIS_OSX_IMAGE} != "xcode7.3" ]; then
+      brew tap wix/brew;
+      brew install applesimutils;
+    fi
 script:
-  - npm test && _FORCE_LOGS=1 npm run mocha -- -R spec build/test/**/*-e2e-specs.js --exit
+  - npm test && _FORCE_LOGS=1 npx mocha -R spec build/test/**/*-e2e-specs.js --exit
 after_success:
   - npm run coverage

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -63,13 +63,13 @@ class Permissions {
   /**
    * Sets permissions for the given application
    *
+   * @param {string} bundleId - bundle identifier of the target application.
    * @param {Object} permissionsMapping - An object, where keys ar  service names
    * and values are corresponding state values. See https://github.com/wix/AppleSimulatorUtils
    * for more details on available service names and statuses.
-   * @param {string} bundleId - bundle identifier of the target application.
    * @throws {Error} If there was an error while changing permissions.
    */
-  async setAccess (permissionsMapping, bundleId) {
+  async setAccess (bundleId, permissionsMapping) {
     const permissionsArg = _.toPairs(permissionsMapping)
       .map((x) => `${x[0]}=${formatStatus(x[1])}`)
       .join(',');
@@ -83,13 +83,13 @@ class Permissions {
   /**
    * Retrieves the current permission status for the given service and application.
    *
+   * @param {string} bundleId - bundle identifier of the target application.
    * @param {string} serviceName - the name of the service. Should be one of
    * `SERVICES` keys.
-   * @param {string} bundleId - bundle identifier of the target application.
    * @returns {string} - The current status: yes/no/unset
    * @throws {Error} If there was an error while retrieving permissions.
    */
-  async getAccess (serviceName, bundleId) {
+  async getAccess (bundleId, serviceName) {
     serviceName = toInternalServiceName(serviceName);
 
     for (const [sqlValue, status] of [['0', STATUS_NO], ['1', STATUS_YES]]) {

--- a/lib/simulator-xcode-11.js
+++ b/lib/simulator-xcode-11.js
@@ -1,0 +1,22 @@
+import SimulatorXcode10 from './simulator-xcode-10';
+import path from 'path';
+import { getDeveloperRoot } from './utils.js';
+
+
+class SimulatorXcode11 extends SimulatorXcode10 {
+  constructor (udid, xcodeVersion) {
+    super(udid, xcodeVersion);
+  }
+
+  /**
+   * @override
+   */
+  async getLaunchDaemonsRoot () {
+    const devRoot = await getDeveloperRoot();
+    return path.resolve(devRoot,
+      'Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/LaunchDaemons');
+  }
+
+}
+
+export default SimulatorXcode11;

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -1125,6 +1125,11 @@ class SimulatorXcode6 extends EventEmitter {
 
   //endregion
 
+
+  async setPermission (bundleId, permission, value) {
+    await this.setPermissions(bundleId, {[permission]: value});
+  }
+
   /**
    * Sets the permissions for the particular application bundle.
    *
@@ -1136,7 +1141,7 @@ class SimulatorXcode6 extends EventEmitter {
    * @throws {Error} If there was an error while changing permissions.
    */
   async setPermissions (bundleId, permissionsMapping) {
-    await this.permissions.setAccess(permissionsMapping, bundleId);
+    await this.permissions.setAccess(bundleId, permissionsMapping);
     log.debug(`Set ${JSON.stringify(permissionsMapping)} access for '${bundleId}'`);
   }
 
@@ -1148,7 +1153,7 @@ class SimulatorXcode6 extends EventEmitter {
    * @throws {Error} If there was an error while retrieving permissions.
    */
   async getPermission (bundleId, serviceName) {
-    const result = await this.permissions.getAccess(serviceName, bundleId);
+    const result = await this.permissions.getAccess(bundleId, serviceName);
     log.debug(`Got ${serviceName} access status for '${bundleId}': ${result}`);
     return result;
   }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -1125,7 +1125,16 @@ class SimulatorXcode6 extends EventEmitter {
 
   //endregion
 
-
+  /**
+   * Sets the particular permission to the application bundle. See
+   * https://github.com/wix/AppleSimulatorUtils for more details on
+   * the available service names and statuses.
+   *
+   * @param {string} bundleId - Application bundle identifier.
+   * @param {string} permission - Service name to be set.
+   * @param {string} value - The desired status for the service.
+   * @throws {Error} If there was an error while changing permission.
+   */
   async setPermission (bundleId, permission, value) {
     await this.setPermissions(bundleId, {[permission]: value});
   }

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -5,6 +5,7 @@ import SimulatorXcode8 from './simulator-xcode-8';
 import SimulatorXcode9 from './simulator-xcode-9';
 import SimulatorXcode93 from './simulator-xcode-9.3';
 import SimulatorXcode10 from './simulator-xcode-10';
+import SimulatorXcode11 from './simulator-xcode-11';
 import { getSimulatorInfo } from './utils';
 import xcode from 'appium-xcode';
 import { log, setLoggingPlatform } from './logger';
@@ -64,6 +65,9 @@ async function getSimulator (udid) {
       break;
     case 10:
       SimClass = SimulatorXcode10;
+      break;
+    case 11:
+      SimClass = SimulatorXcode11;
       break;
     default:
       handleUnsupportedXcode(xcodeVersion);

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -385,7 +385,7 @@ function runTests (deviceType) {
     describe('permissions', function () {
       it(`should properly set and get permissions`, async function () {
         // This test requires WIX simulator utils to be installed
-        if (process.env.DEVICE && parseFloat(process.env.DEVICE) < 10 || process.env.CI) {
+        if (parseFloat(deviceType.version) < 10) {
           return this.skip();
         }
         await sim.setPermission('com.apple.Preferences', 'calendar', 'yes');


### PR DESCRIPTION
This started as just a simple addition of Xcode 11 into the build, but that failed. So...

1. Override `getLaunchDaemonsRoot` for Xcode 11 since the directory structure has changed from `[...]/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/[...]` to `[...]/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/[...]`. _Thanks Apple._
1. Run permissions tests in Travis, since they did not work anywhere. This involved installing the Wix tooling, and adding a function to set a single permission (which seemed to be the idea behind what was written in the test). I also inverted the arguments to some functions so they are all the same.