### PR TITLE
feat: get user installed bundleids by bundlename

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -87,9 +87,14 @@ async function update (pathToPlist, updates) {
 }
 
 async function readSettings (sim, plist) {
-  let settings = {};
-  for (let path of await plistPaths(sim, plist)) {
-    settings[path] = await read(path);
+  const settings = {};
+  for (const path of await plistPaths(sim, plist)) {
+    try {
+      settings[path] = await read(path);
+    } catch (err) {
+      log.warn(`Failed to read plist ${path}. Original error '${err.message}'`);
+      continue;
+    }
   }
   return settings;
 }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -89,18 +89,18 @@ async function update (pathToPlist, updates) {
 async function readSettings (sim, plist) {
   const settings = {};
   for (const path of await plistPaths(sim, plist)) {
-    try {
-      settings[path] = await read(path);
-    } catch (err) {
-      log.warn(`Failed to read plist ${path}. Original error '${err.message}'`);
-      continue;
-    }
+    settings[path] = await read(path);
   }
   return settings;
 }
 
 async function read (pathToPlist) {
-  return await plist.parsePlistFile(pathToPlist, false);
+  try {
+    return await plist.parsePlistFile(pathToPlist, false);
+  } catch (err) {
+    log.warn(`Failed to load ${pathToPlist}. Original error: '${err.message}'`);
+    return {}; // parsePlistFile returns {} by default
+  }
 }
 
 async function updateLocationSettings (sim, bundleId, authorized) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -87,20 +87,15 @@ async function update (pathToPlist, updates) {
 }
 
 async function readSettings (sim, plist) {
-  const settings = {};
-  for (const path of await plistPaths(sim, plist)) {
+  let settings = {};
+  for (let path of await plistPaths(sim, plist)) {
     settings[path] = await read(path);
   }
   return settings;
 }
 
 async function read (pathToPlist) {
-  try {
-    return await plist.parsePlistFile(pathToPlist, false);
-  } catch (err) {
-    log.warn(`Failed to load ${pathToPlist}. Original error: '${err.message}'`);
-    return {}; // parsePlistFile returns {} by default
-  }
+  return await plist.parsePlistFile(pathToPlist, false);
 }
 
 async function updateLocationSettings (sim, bundleId, authorized) {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -188,12 +188,18 @@ class SimulatorXcode6 extends EventEmitter {
   /**
    * Returns user installed bundle ids which has 'bundleName' in their Info.Plist as 'CFBundleName'
    * @param {string} bundleId - The bundle id of the application to be checked.
+   * @return {array<string>} - The list of bundle ids which have 'bundleName'
    */
   async getUserInstalledBundleIdsByBundleName (bundleName) {
-    const rootUserAppDir = await this.buildBundlePathMap('Bundle');
+    const rootUserAppDir = await this.buildBundlePathMap('Bundl');
     const bundleIds = [];
     for (const [key, value] of Object.entries(rootUserAppDir)) {
       const infoPlist = await plist.parsePlistFile(
+        // var path = require('path');
+        // var EXTENSION = '.txt';
+        // var targetFiles = files.filter(function(file) {
+        //     return path.extname(file).toLowerCase() === EXTENSION;
+        // });
         path.resolve(`${await fs.glob(`${value}/*.app`)}`, 'Info.plist'), false);
       if (infoPlist.CFBundleName === bundleName) {
         bundleIds.push(key);
@@ -261,6 +267,11 @@ class SimulatorXcode6 extends EventEmitter {
         let bundleId = await readBundleId(dir);
         return {path: dir, bundleId};
       };
+    }
+
+    if (fs.exists(applicationList)) {
+      log.warn(`No directory path '${applicationList}'`);
+      return {};
     }
 
     let bundlePathDirs = await fs.readdir(applicationList);

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -210,7 +210,7 @@ class SimulatorXcode6 extends EventEmitter {
           bundleIds.push(bundleId);
         }
       } catch (err) {
-        log.warn(`Failed to read plist ${infoPlistPath}. Original error" '${err.message}'`);
+        log.warn(`Failed to read plist ${infoPlistPath}. Original error '${err.message}'`);
         continue;
       }
     }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -2,7 +2,7 @@ import path from 'path';
 import * as simctl from 'node-simctl';
 import { default as xcode, getPath as getXcodePath } from 'appium-xcode';
 import log from './logger';
-import { fs, tempDir, mkdirp } from 'appium-support';
+import { fs, tempDir, mkdirp, plist } from 'appium-support';
 import B from 'bluebird';
 import _ from 'lodash';
 import AsyncLock from 'async-lock';
@@ -15,7 +15,6 @@ import extensions from './extensions/index';
 import { EventEmitter } from 'events';
 import Calendar from './calendar';
 import Permissions from './permissions';
-import { plist } from 'appium-support';
 
 
 const STARTUP_TIMEOUT = 60 * 1000;
@@ -190,13 +189,13 @@ class SimulatorXcode6 extends EventEmitter {
    * Returns user installed bundle ids which has 'bundleName' in their Info.Plist as 'CFBundleName'
    * @param {string} bundleId - The bundle id of the application to be checked.
    */
-  async getBundleIdsByBundleName(bundleName) {
-    const rootPlistDir = await this.buildBundlePathMap('Bundle');
+  async getUserInstalledBundleIdsByBundleName (bundleName) {
+    const rootUserAppDir = await this.buildBundlePathMap('Bundle');
     const bundleIds = [];
-    for (const [key, value] of Object.entries(rootPlistDir)) {
-      const appDir = await fs.glob(`${value}/*.app`);
-      const infoPlist = await plist.parsePlistFile(path.resolve(`${appDir}`, 'Info.plist'), false);
-      if (infoPlist.CFBundleName == bundleName) {
+    for (const [key, value] of Object.entries(rootUserAppDir)) {
+      const infoPlist = await plist.parsePlistFile(
+        path.resolve(`${await fs.glob(`${value}/*.app`)}`, 'Info.plist'), false);
+      if (infoPlist.CFBundleName === bundleName) {
         bundleIds.push(key);
       }
     }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -200,8 +200,11 @@ class SimulatorXcode6 extends EventEmitter {
     for (const [bundleId, userAppDirPath] of Object.entries(rootUserAppDir)) {
       const appFile = (await fs.readdir(userAppDirPath)).find(
         (file) => path.extname(file).toLowerCase() === '.app');
-      const infoPlist = await plist.parsePlistFile(
-        path.resolve(userAppDirPath, appFile, 'Info.plist'), false);
+      const infoPlistPath = path.resolve(userAppDirPath, appFile, 'Info.plist');
+      if (!fs.exists(infoPlistPath)) {
+        continue;
+      }
+      const infoPlist = await plist.parsePlistFile(infoPlistPath, false);
       if (infoPlist.CFBundleName === bundleName) {
         bundleIds.push(bundleId);
       }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -204,9 +204,14 @@ class SimulatorXcode6 extends EventEmitter {
       if (!await fs.exists(infoPlistPath)) {
         continue;
       }
-      const infoPlist = await plist.parsePlistFile(infoPlistPath, false);
-      if (infoPlist.CFBundleName === bundleName) {
-        bundleIds.push(bundleId);
+      try {
+        const infoPlist = await plist.parsePlistFile(infoPlistPath, false);
+        if (infoPlist.CFBundleName === bundleName) {
+          bundleIds.push(bundleId);
+        }
+      } catch (err) {
+        log.warn(`Failed to read plist ${infoPlistPath}. Original error" '${err.message}'`);
+        continue;
       }
     }
     log.debug(`The simulator has '${bundleIds}' which have '${bundleName}' as their 'CFBundleName'`);

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -191,18 +191,19 @@ class SimulatorXcode6 extends EventEmitter {
    * @return {array<string>} - The list of bundle ids which have 'bundleName'
    */
   async getUserInstalledBundleIdsByBundleName (bundleName) {
-    const rootUserAppDir = await this.buildBundlePathMap('Bundl');
+    const rootUserAppDir = await this.buildBundlePathMap('Bundle');
     const bundleIds = [];
-    for (const [key, value] of Object.entries(rootUserAppDir)) {
+    if (_.isEmpty(rootUserAppDir)) {
+      return bundleIds;
+    }
+
+    for (const [bundleId, userAppDirPath] of Object.entries(rootUserAppDir)) {
+      const appFile = (await fs.readdir(userAppDirPath)).find(
+        (file) => path.extname(file).toLowerCase() === '.app');
       const infoPlist = await plist.parsePlistFile(
-        // var path = require('path');
-        // var EXTENSION = '.txt';
-        // var targetFiles = files.filter(function(file) {
-        //     return path.extname(file).toLowerCase() === EXTENSION;
-        // });
-        path.resolve(`${await fs.glob(`${value}/*.app`)}`, 'Info.plist'), false);
+        path.resolve(userAppDirPath, appFile, 'Info.plist'), false);
       if (infoPlist.CFBundleName === bundleName) {
-        bundleIds.push(key);
+        bundleIds.push(bundleId);
       }
     }
     log.debug(`The simulator has '${bundleIds}' which have '${bundleName}' as their 'CFBundleName'`);
@@ -269,7 +270,7 @@ class SimulatorXcode6 extends EventEmitter {
       };
     }
 
-    if (fs.exists(applicationList)) {
+    if (!await fs.exists(applicationList)) {
       log.warn(`No directory path '${applicationList}'`);
       return {};
     }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -15,6 +15,7 @@ import extensions from './extensions/index';
 import { EventEmitter } from 'events';
 import Calendar from './calendar';
 import Permissions from './permissions';
+import { plist } from 'appium-support';
 
 
 const STARTUP_TIMEOUT = 60 * 1000;
@@ -183,6 +184,24 @@ class SimulatorXcode6 extends EventEmitter {
     // `appFile` argument only necessary for iOS below version 8
     let appDirs = await this.getAppDirs(appFile, bundleId);
     return appDirs.length !== 0;
+  }
+
+  /**
+   * Returns user installed bundle ids which has 'bundleName' in their Info.Plist as 'CFBundleName'
+   * @param {string} bundleId - The bundle id of the application to be checked.
+   */
+  async getBundleIdsByBundleName(bundleName) {
+    const rootPlistDir = await this.buildBundlePathMap('Bundle');
+    const bundleIds = [];
+    for (const [key, value] of Object.entries(rootPlistDir)) {
+      const appDir = await fs.glob(`${value}/*.app`);
+      const infoPlist = await plist.parsePlistFile(path.resolve(`${appDir}`, 'Info.plist'), false);
+      if (infoPlist.CFBundleName == bundleName) {
+        bundleIds.push(key);
+      }
+    }
+    log.debug(`The simulator has '${bundleIds}' which have '${bundleName}' as their 'CFBundleName'`);
+    return bundleIds;
   }
 
   /**

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -201,7 +201,7 @@ class SimulatorXcode6 extends EventEmitter {
       const appFile = (await fs.readdir(userAppDirPath)).find(
         (file) => path.extname(file).toLowerCase() === '.app');
       const infoPlistPath = path.resolve(userAppDirPath, appFile, 'Info.plist');
-      if (!fs.exists(infoPlistPath)) {
+      if (!await fs.exists(infoPlistPath)) {
         continue;
       }
       const infoPlist = await plist.parsePlistFile(infoPlistPath, false);

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -446,7 +446,7 @@ function runTests (deviceType) {
       });
 
       // Should be called before launching simulator
-      await simulators[0].getUserInstalledBundleIdsByBundleName('UICatalog').eventually.should.eql([]);
+      await simulators[0].getUserInstalledBundleIdsByBundleName('UICatalog').should.eventually.eql([]);
 
       for (const sim of _.values(simulatorsMapping)) {
         await sim.run({startupTimeout: LONG_TIMEOUT});

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -552,15 +552,16 @@ function runTests (deviceType) {
     });
     it('get bundle ids', async function () {
       let app = testAppPath.iphonesimulator;
-      const exists = await fs.exists(app);
-      if (!exists) {
+      if (!await fs.exists(app)) {
         app = path.resolve(__dirname, '..', '..', '..', 'test', 'assets', 'TestApp-iphonesimulator.app');
       }
       await sim.run({ startupTimeout: LONG_TIMEOUT });
       await sim.installApp(app);
 
       const bundleIds = [];
+      // Xcode 10-
       bundleIds.push(await sim.getUserInstalledBundleIdsByBundleName('UICatalog'));
+      // Xcode 11+ env
       bundleIds.push(await sim.getUserInstalledBundleIdsByBundleName('UIKitCatalog'));
       bundleIds.length.should.above(0);
     });

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -530,6 +530,41 @@ function runTests (deviceType) {
       });
     });
   });
+
+  describe('getUserInstalledBundleIdsByBundleName', function () {
+    this.timeout(LONG_TIMEOUT);
+    let sim;
+
+    before(async function () {
+      await killAllSimulators();
+      let udid = await simctl.createDevice('ios-simulator testing',
+                                       deviceType.device,
+                                       deviceType.version);
+      sim = await getSimulator(udid);
+
+    });
+    after(async function () {
+      await killAllSimulators();
+      await deleteSimulator(sim.udid, deviceType.version);
+    });
+    it('get no bundle id before launching simulator', async function () {
+      await sim.getUserInstalledBundleIdsByBundleName('UICatalog').eventually.should.eql([]);
+    });
+    it('get bundle ids', async function () {
+      let app = testAppPath.iphonesimulator;
+      const exists = await fs.exists(app);
+      if (!exists) {
+        app = path.resolve(__dirname, '..', '..', '..', 'test', 'assets', 'TestApp-iphonesimulator.app');
+      }
+      await sim.run({ startupTimeout: LONG_TIMEOUT });
+      await sim.installApp(app);
+
+      const bundleIds = [];
+      bundleIds.push(await sim.getUserInstalledBundleIdsByBundleName('UICatalog'));
+      bundleIds.push(await sim.getUserInstalledBundleIdsByBundleName('UIKitCatalog'));
+      bundleIds.length.should.above(0);
+    });
+  });
 }
 
 

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -122,7 +122,7 @@ function runTests (deviceType) {
       dirs[0].should.contain('/Data/');
       dirs[1].should.contain('/Bundle/');
 
-      await sim.getUserInstalledBundleIdsByBundleName('TestApp').should.eventually.not.empty();
+      await sim.getUserInstalledBundleIdsByBundleName('TestApp').should.eventually.not.empty;
     });
 
     it('should be able to delete an app', async function () {

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -122,10 +122,7 @@ function runTests (deviceType) {
       dirs[0].should.contain('/Data/');
       dirs[1].should.contain('/Bundle/');
 
-      const bundleIds = [];
-      bundleIds.concat(await sim.getUserInstalledBundleIdsByBundleName('UICatalog')); // Xcode 10-
-      bundleIds.concat(await sim.getUserInstalledBundleIdsByBundleName('UIKitCatalog')); // Xcode 11+
-      bundleIds.length.should.be.above(0);
+      await sim.getUserInstalledBundleIdsByBundleName('TestApp').should.eventually.not.empty();
     });
 
     it('should be able to delete an app', async function () {

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -125,7 +125,7 @@ function runTests (deviceType) {
       const bundleIds = [];
       bundleIds.concat(await sim.getUserInstalledBundleIdsByBundleName('UICatalog')); // Xcode 10-
       bundleIds.concat(await sim.getUserInstalledBundleIdsByBundleName('UIKitCatalog')); // Xcode 11+
-      bundleIds.should.be.above(0);
+      bundleIds.length.should.be.above(0);
     });
 
     it('should be able to delete an app', async function () {

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -535,15 +535,14 @@ function runTests (deviceType) {
     this.timeout(LONG_TIMEOUT);
     let sim;
 
-    before(async function () {
+    beforeEach(async function () {
       await killAllSimulators();
-      let udid = await simctl.createDevice('ios-simulator testing',
-                                       deviceType.device,
-                                       deviceType.version);
+      const udid = await simctl.createDevice(
+        'ios-simulator testing', deviceType.device, deviceType.version);
       sim = await getSimulator(udid);
-
     });
-    after(async function () {
+
+    afterEach(async function () {
       await killAllSimulators();
       await deleteSimulator(sim.udid, deviceType.version);
     });


### PR DESCRIPTION
https://github.com/appium/appium-xcuitest-driver/pull/1052#discussion_r319355030

In like below path has user installed `.app`. This method read Info.plist in the `.app` and returns a list of bundle ids which has provide bundle name.
```
/Users/kazu/Library/Developer/CoreSimulator/Devices/E9245A58-B499-4B76-8FB1-7FA1342F3085/data/Containers/Bundle/Application/210A3413-B313-443A-A5EC-CB6CF1C5E84F/
```