### PR TITLE
fix: clean up logging of bundle ids for bundle name

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -214,7 +214,10 @@ class SimulatorXcode6 extends EventEmitter {
         continue;
       }
     }
-    log.debug(`The simulator has '${bundleIds}' which have '${bundleName}' as their 'CFBundleName'`);
+    log.debug(`The simulator has '${bundleIds.length}' bundles which have '${bundleName}' as their 'CFBundleName':`);
+    for (const bundleId of bundleIds) {
+      log.debug(`    '${bundleId}'`);
+    }
     return bundleIds;
   }
 


### PR DESCRIPTION
If there are no bundle identifiers the current log line looks quite odd.