### PR TITLE
feat: Add setting geolocation by set-simulator-location as the first method

### DIFF
--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -7,21 +7,21 @@ const LYFT_SET_LOCATION = 'set-simulator-location';
 
 /**
  * Set custom geolocation parameters for the given Simulator using LYFT_SET_LOCATION.
- * Nothing will be raised even if the command does not exist or failed to run it.
  *
  * @param {string} udid - The udid to set the given geolocation
  * @param {string|number} latitude - The latitude value, which is going to be entered
  *   into the corresponding edit field, for example '39,0006'.
  * @param {string|number} longitude - The longitude value, which is going to be entered
  *   into the corresponding edit field, for example '19,0068'.
+ * @return {boolean} True if the given geolocation was able to set.
  */
 async function execLyftSetLocation (udid, latitude, longitude) {
   try {
     await fs.which(LYFT_SET_LOCATION);
   } catch (e) {
     log.info(`'${LYFT_SET_LOCATION}' binary has not been found in your PATH. ` +
-    'Please install it following https://github.com/lyft/set-simulator-location to ' +
-    'be able to set geolocation by the library');
+      'Please install it following https://github.com/lyft/set-simulator-location to ' +
+      'be able to set geolocation by the library');
   }
 
   try {
@@ -34,8 +34,19 @@ async function execLyftSetLocation (udid, latitude, longitude) {
     log.warn(`Failed to set geolocation with '${LYFT_SET_LOCATION}'. ` +
       `Original error: ${e.message}`);
   }
+  return false;
 }
 
+/**
+ * Set custom geolocation parameters for the given Simulator using idb.
+ *
+ * @param {Object} idb - The IDB instance
+ * @param {string|number} latitude - The latitude value, which is going to be entered
+ *   into the corresponding edit field, for example '39,0006'.
+ * @param {string|number} longitude - The longitude value, which is going to be entered
+ *   into the corresponding edit field, for example '19,0068'.
+ * @return {boolean} True if the given geolocation was able to set.
+ */
 async function execIbdSetLocation (idb, latitude, longitude) {
   if (idb) {
     try {
@@ -47,8 +58,20 @@ async function execIbdSetLocation (idb, latitude, longitude) {
     return false;
   }
   log.info(`Cannot set geolocation with idb, because it is not installed`);
+  return false;
 }
 
+
+/**
+ * Set custom geolocation parameters for the given Simulator using AppleScript
+ *
+ * @param {Object} sim - The SimulatorXcode object
+ * @param {string|number} latitude - The latitude value, which is going to be entered
+ *   into the corresponding edit field, for example '39,0006'.
+ * @param {string|number} longitude - The longitude value, which is going to be entered
+ *   into the corresponding edit field, for example '19,0068'.
+ * @return {boolean} True if the given geolocation was able to set.
+ */
 async function execAppleScript (sim, latitude, longitude) {
   const output = await sim.executeUIClientScript(`
     tell application "System Events"

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -13,7 +13,7 @@ const LYFT_SET_LOCATION = 'set-simulator-location';
  *   into the corresponding edit field, for example '39,0006'.
  * @param {string|number} longitude - The longitude value, which is going to be entered
  *   into the corresponding edit field, for example '19,0068'.
- * @return {boolean} True if the given geolocation was able to set.
+ * @throws {Error} If it failed to set the location
  */
 async function setLocationWithLyftSetLocation (udid, latitude, longitude) {
   try {
@@ -30,12 +30,10 @@ async function setLocationWithLyftSetLocation (udid, latitude, longitude) {
       '-c', latitude, longitude,
       '-u', udid
     ]);
-    return true;
   } catch (e) {
-    log.warn(`Failed to set geolocation with '${LYFT_SET_LOCATION}'. ` +
+    throw new Error(`Failed to set geolocation with '${LYFT_SET_LOCATION}'. ` +
       `Original error: ${e.message}`);
   }
-  return false;
 }
 
 /**
@@ -46,20 +44,17 @@ async function setLocationWithLyftSetLocation (udid, latitude, longitude) {
  *   into the corresponding edit field, for example '39,0006'.
  * @param {string|number} longitude - The longitude value, which is going to be entered
  *   into the corresponding edit field, for example '19,0068'.
- * @return {boolean} True if the given geolocation was able to set.
+ * @throws {Error} If it failed to set the location
  */
 async function setLocationWithIbdSetLocation (idb, latitude, longitude) {
   if (idb) {
     try {
       await idb.setLocation(latitude, longitude);
-      return true;
     } catch (e) {
-      log.warn(`Failed to set geolocation with idb. Original error: ${e.message}`);
+      throw new Error(`Failed to set geolocation with idb. Original error: ${e.message}`);
     }
-    return false;
   }
-  log.info(`Cannot set geolocation with idb, because it is not installed`);
-  return false;
+  throw new Error('Failed to set geolocation with idb. because it is not installed');
 }
 
 
@@ -71,7 +66,7 @@ async function setLocationWithIbdSetLocation (idb, latitude, longitude) {
  *   into the corresponding edit field, for example '39,0006'.
  * @param {string|number} longitude - The longitude value, which is going to be entered
  *   into the corresponding edit field, for example '19,0068'.
- * @return {boolean} True if the given geolocation was able to set.
+ * @throws {Error} If it failed to set the location
  */
 async function setLocationWithAppleScript (sim, latitude, longitude) {
   const output = await sim.executeUIClientScript(`
@@ -92,7 +87,9 @@ async function setLocationWithAppleScript (sim, latitude, longitude) {
     end tell
   `);
   log.debug(`Geolocation parameters dialog accepted: ${output}`);
-  return _.isString(output) && output.trim() === 'true';
+  if (_.isString(output) && output.trim() !== 'true') {
+    throw new Error('Failed to set geolocation with AppleScript');
+  }
 }
 
 export {

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -15,13 +15,14 @@ const LYFT_SET_LOCATION = 'set-simulator-location';
  *   into the corresponding edit field, for example '19,0068'.
  * @return {boolean} True if the given geolocation was able to set.
  */
-async function execLyftSetLocation (udid, latitude, longitude) {
+async function setLocationWithLyftSetLocation (udid, latitude, longitude) {
   try {
     await fs.which(LYFT_SET_LOCATION);
   } catch (e) {
     log.info(`'${LYFT_SET_LOCATION}' binary has not been found in your PATH. ` +
-      'Please install it following https://github.com/lyft/set-simulator-location to ' +
-      'be able to set geolocation by the library');
+      'Please install it as "brew install lyft/formulae/set-simulator-location" by brew or ' +
+      'read https://github.com/lyft/set-simulator-location to set the binary by manual to ' +
+      'be able to set geolocation by the library.');
   }
 
   try {
@@ -47,7 +48,7 @@ async function execLyftSetLocation (udid, latitude, longitude) {
  *   into the corresponding edit field, for example '19,0068'.
  * @return {boolean} True if the given geolocation was able to set.
  */
-async function execIbdSetLocation (idb, latitude, longitude) {
+async function setLocationWithIbdSetLocation (idb, latitude, longitude) {
   if (idb) {
     try {
       await idb.setLocation(latitude, longitude);
@@ -72,7 +73,7 @@ async function execIbdSetLocation (idb, latitude, longitude) {
  *   into the corresponding edit field, for example '19,0068'.
  * @return {boolean} True if the given geolocation was able to set.
  */
-async function execAppleScript (sim, latitude, longitude) {
+async function setLocationWithAppleScript (sim, latitude, longitude) {
   const output = await sim.executeUIClientScript(`
     tell application "System Events"
       tell process "Simulator"
@@ -95,5 +96,5 @@ async function execAppleScript (sim, latitude, longitude) {
 }
 
 export {
-  execLyftSetLocation, execIbdSetLocation, execAppleScript
+  setLocationWithLyftSetLocation, setLocationWithIbdSetLocation, setLocationWithAppleScript
 };

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -31,17 +31,22 @@ async function execLyftSetLocation (udid, latitude, longitude) {
     ]);
     return true;
   } catch (e) {
-    log.warn(`Failed to set geolocation by '${LYFT_SET_LOCATION}'. ` +
+    log.warn(`Failed to set geolocation with '${LYFT_SET_LOCATION}'. ` +
       `Original error: ${e.message}`);
   }
 }
 
 async function execIbdSetLocation (idb, latitude, longitude) {
   if (idb) {
-    await idb.setLocation(latitude, longitude);
-    return true;
+    try {
+      await idb.setLocation(latitude, longitude);
+      return true;
+    } catch (e) {
+      log.warn(`Failed to set geolocation with idb. Original error: ${e.message}`);
+    }
+    return false;
   }
-  log.warn(`Cannot set geolocation with idb, because it is not installed. Defaulting to AppleScript`);
+  log.info(`Cannot set geolocation with idb, because it is not installed`);
 }
 
 async function execAppleScript (sim, latitude, longitude) {

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -15,11 +15,11 @@ const LYFT_SET_LOCATION = 'set-simulator-location';
  *   into the corresponding edit field, for example '19,0068'.
  * @throws {Error} If it failed to set the location
  */
-async function setLocationWithLyftSetLocation (udid, latitude, longitude) {
+async function setLocationWithLyft (udid, latitude, longitude) {
   try {
     await fs.which(LYFT_SET_LOCATION);
   } catch (e) {
-    log.info(`'${LYFT_SET_LOCATION}' binary has not been found in your PATH. ` +
+    throw new Error(`'${LYFT_SET_LOCATION}' binary has not been found in your PATH. ` +
       'Please install it as "brew install lyft/formulae/set-simulator-location" by brew or ' +
       'read https://github.com/lyft/set-simulator-location to set the binary by manual to ' +
       'be able to set geolocation by the library.');
@@ -32,7 +32,7 @@ async function setLocationWithLyftSetLocation (udid, latitude, longitude) {
     ]);
   } catch (e) {
     throw new Error(`Failed to set geolocation with '${LYFT_SET_LOCATION}'. ` +
-      `Original error: ${e.message}`);
+      `Original error: ${e.stderr || e.message}`);
   }
 }
 
@@ -46,15 +46,15 @@ async function setLocationWithLyftSetLocation (udid, latitude, longitude) {
  *   into the corresponding edit field, for example '19,0068'.
  * @throws {Error} If it failed to set the location
  */
-async function setLocationWithIbdSetLocation (idb, latitude, longitude) {
+async function setLocationWithIdb (idb, latitude, longitude) {
   if (idb) {
     try {
       await idb.setLocation(latitude, longitude);
     } catch (e) {
-      throw new Error(`Failed to set geolocation with idb. Original error: ${e.message}`);
+      throw new Error(`Failed to set geolocation with idb. Original error: ${e.stderr || e.message}`);
     }
   }
-  throw new Error('Failed to set geolocation with idb. because it is not installed');
+  throw new Error('Failed to set geolocation with idb because it is not installed');
 }
 
 
@@ -87,11 +87,11 @@ async function setLocationWithAppleScript (sim, latitude, longitude) {
     end tell
   `);
   log.debug(`Geolocation parameters dialog accepted: ${output}`);
-  if (_.isString(output) && output.trim() !== 'true') {
-    throw new Error('Failed to set geolocation with AppleScript');
+  if (_.trim(output) !== 'true') {
+    throw new Error(`Failed to set geolocation with AppleScript. Original error: ${output}`);
   }
 }
 
 export {
-  setLocationWithLyftSetLocation, setLocationWithIbdSetLocation, setLocationWithAppleScript
+  setLocationWithLyft, setLocationWithIdb, setLocationWithAppleScript
 };

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -1,0 +1,71 @@
+import _ from 'lodash';
+import log from './logger';
+import { exec } from 'teen_process';
+import { fs } from 'appium-support';
+
+const LYFT_SET_LOCATION = 'set-simulator-location';
+
+/**
+ * Set custom geolocation parameters for the given Simulator using LYFT_SET_LOCATION.
+ * Nothing will be raised even if the command does not exist or failed to run it.
+ *
+ * @param {string} udid - The udid to set the given geolocation
+ * @param {string|number} latitude - The latitude value, which is going to be entered
+ *   into the corresponding edit field, for example '39,0006'.
+ * @param {string|number} longitude - The longitude value, which is going to be entered
+ *   into the corresponding edit field, for example '19,0068'.
+ */
+async function execLyftSetLocation (udid, latitude, longitude) {
+  try {
+    await fs.which(LYFT_SET_LOCATION);
+  } catch (e) {
+    log.info(`'${LYFT_SET_LOCATION}' binary has not been found in your PATH. ` +
+    'Please install it following https://github.com/lyft/set-simulator-location to ' +
+    'be able to set geolocation by the library');
+  }
+
+  try {
+    await exec(LYFT_SET_LOCATION, [
+      '-c', latitude, longitude,
+      '-u', udid
+    ]);
+    return true;
+  } catch (e) {
+    log.warn(`Failed to set geolocation by '${LYFT_SET_LOCATION}'. ` +
+      `Original error: ${e.message}`);
+  }
+}
+
+async function execIbdSetLocation (idb, latitude, longitude) {
+  if (idb) {
+    await idb.setLocation(latitude, longitude);
+    return true;
+  }
+  log.warn(`Cannot set geolocation with idb, because it is not installed. Defaulting to AppleScript`);
+}
+
+async function execAppleScript (sim, latitude, longitude) {
+  const output = await sim.executeUIClientScript(`
+    tell application "System Events"
+      tell process "Simulator"
+        set featureName to "Custom Location"
+        set dstMenuItem to menu item (featureName & "…") of menu 1 of menu item "Location" of menu 1 of menu bar item "Debug" of menu bar 1
+        click dstMenuItem
+        delay 1
+        set value of text field 1 of window featureName to ${latitude} as string
+        delay 0.5
+        set value of text field 2 of window featureName to ${longitude} as string
+        delay 0.5
+        click button "OK" of window featureName
+        delay 0.5
+        set isInvisible to (not (exists (window featureName)))
+      end tell
+    end tell
+  `);
+  log.debug(`Geolocation parameters dialog accepted: ${output}`);
+  return _.isString(output) && output.trim() === 'true';
+}
+
+export {
+  execLyftSetLocation, execIbdSetLocation, execAppleScript
+};

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -286,29 +286,23 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    * @throws {Error} If there was an error while setting the location
    */
   async setGeolocation (latitude, longitude) {
-    try {
-      await setLocationWithLyft(this.udid, latitude, longitude);
-      return true;
-    } catch (e) {
-      log.warn(e.message);
-    }
+    const locationSetters = [
+      async () => await setLocationWithLyft(this.udid, latitude, longitude),
+      async () => await setLocationWithIdb(this.idb, latitude, longitude),
+      async () => await setLocationWithAppleScript(this, latitude, longitude)
+    ];
 
-    try {
-      await setLocationWithIdb(this.idb, latitude, longitude);
-      return true;
-    } catch (e) {
-      log.warn(e.message);
+    let lastError;
+    for (const setter of locationSetters) {
+      try {
+        await setter();
+        return true;
+      } catch (e) {
+        log.info(e.message);
+        lastError = e;
+      }
     }
-
-    try {
-      await setLocationWithAppleScript(this, latitude, longitude);
-      return true;
-    } catch (e) {
-      log.warn(e.message);
-    }
-
-    log.errorAndThrow('Failed to set geolocation with possible methods. ' +
-      'Please read the server log what kind of methods Appium tried.');
+    throw lastError;
   }
 }
 

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -6,14 +6,13 @@ import { waitForCondition } from 'asyncbox';
 import { exec } from 'teen_process';
 import { getAppContainer, openUrl as simctlOpenUrl, terminate,
          appInfo, spawn, startBootMonitor } from 'node-simctl';
-import { fs } from 'appium-support';
+import { execLyftSetLocation, execIbdSetLocation, execAppleScript } from './geolocation';
 
 // these sims are sloooooooow
 const STARTUP_TIMEOUT = 120 * 1000;
 const SAFARI_STARTUP_TIMEOUT = 25 * 1000;
 const MOBILE_SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const PROCESS_LAUNCH_OK_PATTERN = (bundleId) => new RegExp(`${bundleId.replace('.', '\\.')}:\\s+\\d+`);
-const LYFT_SET_LOCATION = 'set-simulator-location';
 
 class SimulatorXcode8 extends SimulatorXcode7 {
   constructor (udid, xcodeVersion) {
@@ -284,40 +283,9 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    * @throws {Error} If there was an error while setting the location
    */
   async setGeolocation (latitude, longitude) {
-    try {
-      await fs.which(LYFT_SET_LOCATION);
-      await exec(LYFT_SET_LOCATION, [
-        '-c', latitude, longitude,
-        '-u', this.udid
-      ]);
-      return true;
-    } catch (ign) {}
-    log.warn(`Cannot set geolocation with ${LYFT_SET_LOCATION}, because it is not installed or failed to set.`);
-
-    if (this.idb) {
-      await this.idb.setLocation(latitude, longitude);
-      return true;
-    }
-    log.warn(`Cannot set geolocation with idb, because it is not installed. Defaulting to AppleScript`);
-    const output = await this.executeUIClientScript(`
-      tell application "System Events"
-        tell process "Simulator"
-          set featureName to "Custom Location"
-          set dstMenuItem to menu item (featureName & "…") of menu 1 of menu item "Location" of menu 1 of menu bar item "Debug" of menu bar 1
-          click dstMenuItem
-          delay 1
-          set value of text field 1 of window featureName to ${latitude} as string
-          delay 0.5
-          set value of text field 2 of window featureName to ${longitude} as string
-          delay 0.5
-          click button "OK" of window featureName
-          delay 0.5
-          set isInvisible to (not (exists (window featureName)))
-        end tell
-      end tell
-    `);
-    log.debug(`Geolocation parameters dialog accepted: ${output}`);
-    return _.isString(output) && output.trim() === 'true';
+    return await execLyftSetLocation(this.udid, latitude, longitude)
+      || await execIbdSetLocation(this.idb, latitude, longitude)
+      || await execAppleScript(this, latitude, longitude);
   }
 }
 

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -286,9 +286,29 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    * @throws {Error} If there was an error while setting the location
    */
   async setGeolocation (latitude, longitude) {
-    return await setLocationWithLyftSetLocation(this.udid, latitude, longitude)
-      || await setLocationWithIbdSetLocation(this.idb, latitude, longitude)
-      || await setLocationWithAppleScript(this, latitude, longitude);
+    try {
+      await setLocationWithLyftSetLocation(this.udid, latitude, longitude);
+      return true;
+    } catch (e) {
+      log.warn(e.message);
+    }
+
+    try {
+      await setLocationWithIbdSetLocation(this.idb, latitude, longitude);
+      return true;
+    } catch (e) {
+      log.warn(e.message);
+    }
+
+    try {
+      await setLocationWithAppleScript(this, latitude, longitude);
+      return true;
+    } catch (e) {
+      log.warn(e.message);
+    }
+
+    log.errorAndThrow('Failed to set geolocation with possible methods. ' +
+      'Please read the server log for more details.');
   }
 }
 

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -6,12 +6,14 @@ import { waitForCondition } from 'asyncbox';
 import { exec } from 'teen_process';
 import { getAppContainer, openUrl as simctlOpenUrl, terminate,
          appInfo, spawn, startBootMonitor } from 'node-simctl';
+import { fs } from 'appium-support';
 
 // these sims are sloooooooow
 const STARTUP_TIMEOUT = 120 * 1000;
 const SAFARI_STARTUP_TIMEOUT = 25 * 1000;
 const MOBILE_SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
 const PROCESS_LAUNCH_OK_PATTERN = (bundleId) => new RegExp(`${bundleId.replace('.', '\\.')}:\\s+\\d+`);
+const LYFT_SET_LOCATION = 'set-simulator-location';
 
 class SimulatorXcode8 extends SimulatorXcode7 {
   constructor (udid, xcodeVersion) {
@@ -282,6 +284,16 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    * @throws {Error} If there was an error while setting the location
    */
   async setGeolocation (latitude, longitude) {
+    try {
+      await fs.which(LYFT_SET_LOCATION);
+      await exec(LYFT_SET_LOCATION, [
+        '-c', latitude, longitude,
+        '-u', this.udid
+      ]);
+      return true;
+    } catch (ign) {}
+    log.warn(`Cannot set geolocation with ${LYFT_SET_LOCATION}, because it is not installed or failed to set.`);
+
     if (this.idb) {
       await this.idb.setLocation(latitude, longitude);
       return true;

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -308,7 +308,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     }
 
     log.errorAndThrow('Failed to set geolocation with possible methods. ' +
-      'Please read the server log for more details.');
+      'Please read the server log what kind of methods Appium tried.');
   }
 }
 

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -7,8 +7,8 @@ import { exec } from 'teen_process';
 import { getAppContainer, openUrl as simctlOpenUrl, terminate,
          appInfo, spawn, startBootMonitor } from 'node-simctl';
 import {
-  setLocationWithLyftSetLocation,
-  setLocationWithIbdSetLocation,
+  setLocationWithLyft,
+  setLocationWithIdb,
   setLocationWithAppleScript } from './geolocation';
 
 // these sims are sloooooooow
@@ -287,14 +287,14 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    */
   async setGeolocation (latitude, longitude) {
     try {
-      await setLocationWithLyftSetLocation(this.udid, latitude, longitude);
+      await setLocationWithLyft(this.udid, latitude, longitude);
       return true;
     } catch (e) {
       log.warn(e.message);
     }
 
     try {
-      await setLocationWithIbdSetLocation(this.idb, latitude, longitude);
+      await setLocationWithIdb(this.idb, latitude, longitude);
       return true;
     } catch (e) {
       log.warn(e.message);

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -6,7 +6,10 @@ import { waitForCondition } from 'asyncbox';
 import { exec } from 'teen_process';
 import { getAppContainer, openUrl as simctlOpenUrl, terminate,
          appInfo, spawn, startBootMonitor } from 'node-simctl';
-import { execLyftSetLocation, execIbdSetLocation, execAppleScript } from './geolocation';
+import {
+  setLocationWithLyftSetLocation,
+  setLocationWithIbdSetLocation,
+  setLocationWithAppleScript } from './geolocation';
 
 // these sims are sloooooooow
 const STARTUP_TIMEOUT = 120 * 1000;
@@ -283,9 +286,9 @@ class SimulatorXcode8 extends SimulatorXcode7 {
    * @throws {Error} If there was an error while setting the location
    */
   async setGeolocation (latitude, longitude) {
-    return await execLyftSetLocation(this.udid, latitude, longitude)
-      || await execIbdSetLocation(this.idb, latitude, longitude)
-      || await execAppleScript(this, latitude, longitude);
+    return await setLocationWithLyftSetLocation(this.udid, latitude, longitude)
+      || await setLocationWithIbdSetLocation(this.idb, latitude, longitude)
+      || await setLocationWithAppleScript(this, latitude, longitude);
   }
 }
 


### PR DESCRIPTION
https://github.com/lyft/set-simulator-location

This works on Xcode 11.2 environment on my env. (against iOS 12 and iOS 13)
Current idb does not work well on Xcode 11 env, so, let's try another way before idb try.

- ok
```
[HTTP] --> POST /wd/hub/session/857ac20d-beac-4409-ac0a-75a37aa833c9/location
[HTTP] {"location":{"latitude":34.18583,"longitude":131.47139,"altitude":0}}
[debug] [W3C (857ac20d)] Calling AppiumDriver.setGeoLocation() with args: [{"latitude":34.18583,"longitude":131.47139,"altitude":0},"857ac20d-beac-4409-ac0a-75a37aa833c9"]
[debug] [XCUITest] Executing command 'setGeoLocation'
[debug] [W3C (857ac20d)] Responding to client with driver.setGeoLocation() result: null
[HTTP] <-- POST /wd/hub/session/857ac20d-beac-4409-ac0a-75a37aa833c9/location 200 279 ms - 14
[HTTP]
```

- fail
```
[HTTP] --> POST /wd/hub/session/ae50e600-8efd-440a-8a92-89f50018ff24/location
[HTTP] {"location":{"latitude":34.18583,"longitude":131.47139,"altitude":0}}
[debug] [W3C (ae50e600)] Calling AppiumDriver.setGeoLocation() with args: [{"latitude":34.18583,"longitude":131.47139,"altitude":0},"ae50e600-8efd-440a-8a92-89f50018ff24"]
[debug] [XCUITest] Executing command 'setGeoLocation'
[iOSSim] Cannot set geolocation with set-simulator-location, because it is not installed or failed to set.
[iOSSim] Cannot set geolocation with idb, because it is not installed. Defaulting to AppleScript
[iOSSim] Cannot focus Simulator window with idb. Defaulting to AppleScript
[debug] [iOSSim] Executing UI Apple Script on Simulator with UDID 3709FCFA-C989-437A-9929-615944085CB8:
[debug] [iOSSim]       tell application "System Events"
[debug] [iOSSim]         tell process "Simulator"
[debug] [iOSSim]           set frontmost to false
[debug] [iOSSim]           set frontmost to true
[debug] [iOSSim]           click (menu item 1 where (its name contains "iPhone 11 " and its name contains "13.2")) of menu 1 of menu bar item "Window" of menu bar 1
[debug] [iOSSim]         end tell
[debug] [iOSSim]       end tell
[debug] [iOSSim]
[debug] [iOSSim]
[debug] [iOSSim]       tell application "System Events"
[debug] [iOSSim]         tell process "Simulator"
[debug] [iOSSim]           set featureName to "Custom Location"
[debug] [iOSSim]           set dstMenuItem to menu item (featureName & "…") of menu 1 of menu item "Location" of menu 1 of menu bar item "Debug" of menu bar 1
[debug] [iOSSim]           click dstMenuItem
[debug] [iOSSim]           delay 1
[debug] [iOSSim]           set value of text field 1 of window featureName to 34.18583 as string
[debug] [iOSSim]           delay 0.5
[debug] [iOSSim]           set value of text field 2 of window featureName to 131.47139 as string
[debug] [iOSSim]           delay 0.5
[debug] [iOSSim]           click button "OK" of window featureName
[debug] [iOSSim]           delay 0.5
[debug] [iOSSim]           set isInvisible to (not (exists (window featureName)))
[debug] [iOSSim]         end tell
[debug] [iOSSim]       end tell
[debug] [iOSSim]
[debug] [iOSSim] Geolocation parameters dialog accepted: true
[debug] [iOSSim]
[debug] [W3C (ae50e600)] Responding to client with driver.setGeoLocation() result: null
[HTTP] <-- POST /wd/hub/session/ae50e6
```