### PR TITLE
feat: allow passing in of platform

### DIFF
--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -24,7 +24,7 @@ function handleUnsupportedXcode (xcodeVersion) {
  *
  * @param {string} udid - The ID of an existing Simulator.
  * @param {Object} opts - an Options object that can include the `platform` of
- *                        the simulator associated with the udid, and `checkExistance`,
+ *                        the simulator associated with the udid, and `checkExistence`,
  *                        which allows one to skip checking that the udid is valid
  *                        (defaults to `true`)
  * @throws {Error} If the Simulator with given udid does not exist in devices list.
@@ -34,12 +34,12 @@ function handleUnsupportedXcode (xcodeVersion) {
  */
 async function getSimulator (udid, opts = {}) {
   let {
-    platform,
-    checkExistance = true,
+    platform = 'iOS',
+    checkExistence = true,
   } = opts;
 
   const xcodeVersion = await xcode.getVersion(true);
-  if (checkExistance) {
+  if (checkExistence) {
     const simulatorInfo = await getSimulatorInfo(udid);
 
     if (!simulatorInfo) {
@@ -52,7 +52,7 @@ async function getSimulator (udid, opts = {}) {
   // make sure we have the right logging prefix
   setLoggingPlatform(platform);
 
-  log.info(`Constructing ${platform || 'iOS'} simulator for Xcode version ${xcodeVersion.versionString} ` +
+  log.info(`Constructing ${platform} simulator for Xcode version ${xcodeVersion.versionString} ` +
            `with udid '${udid}'`);
   let SimClass;
   switch (xcodeVersion.major) {

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -23,23 +23,36 @@ function handleUnsupportedXcode (xcodeVersion) {
  * Finds and returns the corresponding Simulator instance for the given ID.
  *
  * @param {string} udid - The ID of an existing Simulator.
+ * @param {Object} opts - an Options object that can include the `platform` of
+ *                        the simulator associated with the udid, and `checkExistance`,
+ *                        which allows one to skip checking that the udid is valid
+ *                        (defaults to `true`)
  * @throws {Error} If the Simulator with given udid does not exist in devices list.
  *   If you want to create a new simulator, you can use the `createDevice()` method of
  *   [node-simctl](github.com/appium/node-simctl).
  * @return {object} Simulator object associated with the udid passed in.
  */
-async function getSimulator (udid) {
-  const xcodeVersion = await xcode.getVersion(true);
-  const simulatorInfo = await getSimulatorInfo(udid);
+async function getSimulator (udid, opts = {}) {
+  let {
+    platform,
+    checkExistance = true,
+  } = opts;
 
-  if (!simulatorInfo) {
-    throw new Error(`No sim found with udid '${udid}'`);
+  const xcodeVersion = await xcode.getVersion(true);
+  if (checkExistance) {
+    const simulatorInfo = await getSimulatorInfo(udid);
+
+    if (!simulatorInfo) {
+      throw new Error(`No sim found with udid '${udid}'`);
+    }
+
+    platform = simulatorInfo.platform;
   }
 
   // make sure we have the right logging prefix
-  setLoggingPlatform(simulatorInfo.platform);
+  setLoggingPlatform(platform);
 
-  log.info(`Constructing ${simulatorInfo.platform || 'iOS'} simulator for Xcode version ${xcodeVersion.versionString} ` +
+  log.info(`Constructing ${platform || 'iOS'} simulator for Xcode version ${xcodeVersion.versionString} ` +
            `with udid '${udid}'`);
   let SimClass;
   switch (xcodeVersion.major) {
@@ -73,6 +86,7 @@ async function getSimulator (udid) {
       handleUnsupportedXcode(xcodeVersion);
       SimClass = SimulatorXcode93;
   }
+
   return new SimClass(udid, xcodeVersion);
 }
 


### PR DESCRIPTION
There are times when we know, when calling `getSimulator`, that the simulator exists (for instance, when we have just created it). On my machine, using iOS 13+, it takes around 10 seconds to check for the existence of the simulator, so skipping it is not a trivial thing.