### PR TITLE
feat: disable pasteboard sync in launching time to improve the performance

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -480,7 +480,7 @@ class SimulatorXcode6 extends EventEmitter {
         // Do not add -PasteboardAutomaticSync
         break;
       default:
-        log.warn(`pasteboardAutomaticSync capability accepts one of ['on', 'off' or 'system']. Follows 'off' as default.`);
+        log.warn(`['on', 'off' or 'system'] are available as the pasteboard automatic sync option. Defaulting to 'off'.`);
         args.push('-PasteboardAutomaticSync', '0');
     }
 

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -457,6 +457,10 @@ class SimulatorXcode6 extends EventEmitter {
       args.push('-ConnectHardwareKeyboard', opts.connectHardwareKeyboard ? '1' : '0');
     }
 
+    // Improve launching simulator performance
+    // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
+    args.push('-PasteboardAutomaticSync', '0');
+
     log.info(`Starting Simulator UI with command: open ${args.join(' ')}`);
     try {
       await exec('open', args, {timeout: opts.startupTimeout});

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -424,21 +424,26 @@ class SimulatorXcode6 extends EventEmitter {
     return indicator;
   }
 
+
+  /**
+   * @typedef {Object} SimulatorOptions
+   * @property {?string} - Defines the window scale value for the UI client window for the current Simulator.
+   *   Equals to null by default, which keeps the current scale unchanged.
+   *   It should be one of ['1.0', '0.75', '0.5', '0.33', '0.25'].
+   * @property {boolean} connectHardwareKeyboard - Whether to connect the hardware keyboard to the
+   *   Simulator UI client. Defaults to false.
+   * @property {boolean} disablePasteboardAutomaticSync - Whether to disable pasteboard sync with the
+   *   Simulator UI client or respect the system wide preference.
+   *   The sync increase launching simulator process time, but it allows system to sync pasteboard
+   *   with simulators. Follows system-wide preference if the value is false.
+   *   Defaults to true.
+   * @property {number} startupTimeout - Number of milliseconds to wait until Simulator booting
+   *   process is completed. The default timeout will be used if not set explicitly.
+   */
+
   /**
    * Start the Simulator UI client with the given arguments
-   *
-   * @param {object} opts - One or more of available Simulator UI client options:
-   *   - {string} scaleFactor: can be one of ['1.0', '0.75', '0.5', '0.33', '0.25'].
-   *   Defines the window scale value for the UI client window for the current Simulator.
-   *   Equals to null by default, which keeps the current scale unchanged.
-   *   - {boolean} connectHardwareKeyboard: whether to connect the hardware keyboard to the
-   *   Simulator UI client. Equals to false by default.
-   *   - {boolean} disablePasteboardAutomaticSync: whether to disable pasteboard sync with the
-   *   Simulator UI client. It increases launching simulator process time, but it allows system
-   *   to sync pasteboard with simulators. Follows system-wide preference if the value is false.
-   *   Defaults to true.
-   *   - {number} startupTimeout: number of milliseconds to wait until Simulator booting
-   *   process is completed. The default timeout will be used if not set explicitly.
+   * @param {Object} SimulatorOptions - Simulator launching options
    */
   async startUIClient (opts = {}) {
     opts = Object.assign({
@@ -462,8 +467,9 @@ class SimulatorXcode6 extends EventEmitter {
       args.push('-ConnectHardwareKeyboard', opts.connectHardwareKeyboard ? '1' : '0');
     }
 
-    if (_.isBoolean(opts.disablePasteboardAutomaticSync)) {
-      // Improve launching simulator performance
+    if (_.isBoolean(opts.disablePasteboardAutomaticSync) && opts.disablePasteboardAutomaticSync) {
+      // Improve launching simulator performance.
+      // Respect system wide preference if disablePasteboardAutomaticSync was false.
       // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
       args.push('-PasteboardAutomaticSync', '0');
     }

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -432,11 +432,11 @@ class SimulatorXcode6 extends EventEmitter {
    *   It should be one of ['1.0', '0.75', '0.5', '0.33', '0.25'].
    * @property {boolean} connectHardwareKeyboard [false] - Whether to connect the hardware keyboard to the
    *   Simulator UI client. Defaults to false.
-   * @property {boolean} disablePasteboardAutomaticSync [true] - Whether to disable pasteboard sync with the
-   *   Simulator UI client or respect the system wide preference.
-   *   The sync increase launching simulator process time, but it allows system to sync pasteboard
-   *   with simulators. Follows system-wide preference if the value is false.
-   *   Defaults to true.
+   * @property {string} pasteboardAutomaticSync ['off'] - Whether to disable pasteboard sync with the
+   *   Simulator UI client or respect the system wide preference. 'on', 'off', or 'system' is available.
+   *   The sync increases launching simulator process time, but it allows system to sync pasteboard
+   *   with simulators. Follows system-wide preference if the value is 'system'.
+   *   Defaults to 'off'.
    * @property {number} startupTimeout [60000] - Number of milliseconds to wait until Simulator booting
    *   process is completed. The default timeout will be used if not set explicitly.
    */
@@ -449,7 +449,7 @@ class SimulatorXcode6 extends EventEmitter {
     opts = Object.assign({
       scaleFactor: null,
       connectHardwareKeyboard: false,
-      disablePasteboardAutomaticSync: true,
+      pasteboardAutomaticSync: 'off',
       startupTimeout: this.startupTimeout,
     }, opts);
 
@@ -467,11 +467,21 @@ class SimulatorXcode6 extends EventEmitter {
       args.push('-ConnectHardwareKeyboard', opts.connectHardwareKeyboard ? '1' : '0');
     }
 
-    if (_.isBoolean(opts.disablePasteboardAutomaticSync) && opts.disablePasteboardAutomaticSync) {
-      // Improve launching simulator performance.
-      // Respect system wide preference if disablePasteboardAutomaticSync was false.
-      // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
-      args.push('-PasteboardAutomaticSync', '0');
+    switch (_.lowerCase(opts.pasteboardAutomaticSync)) {
+      case 'on':
+        args.push('-PasteboardAutomaticSync', '1');
+        break;
+      case 'off':
+        // Improve launching simulator performance
+        // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
+        args.push('-PasteboardAutomaticSync', '0');
+        break;
+      case 'system':
+        // Do not add -PasteboardAutomaticSync
+        break;
+      default:
+        log.warn(`pasteboardAutomaticSync capability accepts one of ['on', 'off' or 'system']. Follows 'off' as default.`);
+        args.push('-PasteboardAutomaticSync', '0');
     }
 
     log.info(`Starting Simulator UI with command: open ${args.join(' ')}`);

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -427,23 +427,23 @@ class SimulatorXcode6 extends EventEmitter {
 
   /**
    * @typedef {Object} SimulatorOptions
-   * @property {?string} - Defines the window scale value for the UI client window for the current Simulator.
+   * @property {?string} scaleFactor [null] - Defines the window scale value for the UI client window for the current Simulator.
    *   Equals to null by default, which keeps the current scale unchanged.
    *   It should be one of ['1.0', '0.75', '0.5', '0.33', '0.25'].
-   * @property {boolean} connectHardwareKeyboard - Whether to connect the hardware keyboard to the
+   * @property {boolean} connectHardwareKeyboard [false] - Whether to connect the hardware keyboard to the
    *   Simulator UI client. Defaults to false.
-   * @property {boolean} disablePasteboardAutomaticSync - Whether to disable pasteboard sync with the
+   * @property {boolean} disablePasteboardAutomaticSync [true] - Whether to disable pasteboard sync with the
    *   Simulator UI client or respect the system wide preference.
    *   The sync increase launching simulator process time, but it allows system to sync pasteboard
    *   with simulators. Follows system-wide preference if the value is false.
    *   Defaults to true.
-   * @property {number} startupTimeout - Number of milliseconds to wait until Simulator booting
+   * @property {number} startupTimeout [60000] - Number of milliseconds to wait until Simulator booting
    *   process is completed. The default timeout will be used if not set explicitly.
    */
 
   /**
    * Start the Simulator UI client with the given arguments
-   * @param {Object} SimulatorOptions - Simulator launching options
+   * @param {SimulatorOptions} opts - Simulator launching options
    */
   async startUIClient (opts = {}) {
     opts = Object.assign({

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -433,6 +433,10 @@ class SimulatorXcode6 extends EventEmitter {
    *   Equals to null by default, which keeps the current scale unchanged.
    *   - {boolean} connectHardwareKeyboard: whether to connect the hardware keyboard to the
    *   Simulator UI client. Equals to false by default.
+   *   - {boolean} disablePasteboardAutomaticSync: whether to disable pasteboard sync with the
+   *   Simulator UI client. It increases launching simulator process time, but it allows system
+   *   to sync pasteboard with simulators. Follows system-wide preference if the value is false.
+   *   Defaults to true.
    *   - {number} startupTimeout: number of milliseconds to wait until Simulator booting
    *   process is completed. The default timeout will be used if not set explicitly.
    */
@@ -440,6 +444,7 @@ class SimulatorXcode6 extends EventEmitter {
     opts = Object.assign({
       scaleFactor: null,
       connectHardwareKeyboard: false,
+      disablePasteboardAutomaticSync: true,
       startupTimeout: this.startupTimeout,
     }, opts);
 
@@ -457,9 +462,11 @@ class SimulatorXcode6 extends EventEmitter {
       args.push('-ConnectHardwareKeyboard', opts.connectHardwareKeyboard ? '1' : '0');
     }
 
-    // Improve launching simulator performance
-    // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
-    args.push('-PasteboardAutomaticSync', '0');
+    if (_.isBoolean(opts.disablePasteboardAutomaticSync)) {
+      // Improve launching simulator performance
+      // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
+      args.push('-PasteboardAutomaticSync', '0');
+    }
 
     log.info(`Starting Simulator UI with command: open ${args.join(' ')}`);
     try {


### PR DESCRIPTION
Reference: 
- https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
- https://twitter.com/steipete/status/1227551552317140992?s=20

This argument improves launching simulator performance.
Once this pasteboard sync disabled, the pasteboard cannot sync with macOS system with simulators. In a case a user would like to sync such pasteboard, I'd like to add `disablePasteboardAutomaticSync` as caps.

https://github.com/appium/appium-ios-driver/blob/master/lib/desired-caps.js

Then, `PasteboardAutomaticSync` follows the global preference.

```
defaults read com.apple.iphonesimulator PasteboardAutomaticSync
```

On my machine, this disableness improved the launching performance around two seconds.