### PR TITLE
fix: allow Xcode 11.4 geolocation setting through AppleScript

### DIFF
--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -66,14 +66,15 @@ async function setLocationWithIdb (idb, latitude, longitude) {
  *   into the corresponding edit field, for example '39,0006'.
  * @param {string|number} longitude - The longitude value, which is going to be entered
  *   into the corresponding edit field, for example '19,0068'.
+ * @param {string} [menu=Debug] - The menu field in which the 'Location' feature is found
  * @throws {Error} If it failed to set the location
  */
-async function setLocationWithAppleScript (sim, latitude, longitude) {
+async function setLocationWithAppleScript (sim, latitude, longitude, menu = 'Debug') {
   const output = await sim.executeUIClientScript(`
     tell application "System Events"
       tell process "Simulator"
         set featureName to "Custom Location"
-        set dstMenuItem to menu item (featureName & "…") of menu 1 of menu item "Location" of menu 1 of menu bar item "Debug" of menu bar 1
+        set dstMenuItem to menu item (featureName & "…") of menu 1 of menu item "Location" of menu 1 of menu bar item "${menu}" of menu bar 1
         click dstMenuItem
         delay 1
         set value of text field 1 of window featureName to ${latitude} as string

--- a/lib/simulator-xcode-11.4.js
+++ b/lib/simulator-xcode-11.4.js
@@ -23,6 +23,10 @@ const NATIVE_SIMCTL_PERMISSIONS = [
 class SimulatorXcode11_4 extends SimulatorXcode11 {
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
+
+    // for setting the location using AppleScript, the top-level menu through which
+    // the 'Location' option is found
+    this._locationMenu = 'Features';
   }
 
   /**

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -30,6 +30,10 @@ class SimulatorXcode8 extends SimulatorXcode7 {
       'var/run/syslog.pid'
     ];
     this._idb = null;
+
+    // for setting the location using AppleScript, the top-level menu through which
+    // the 'Location' option is found
+    this._locationMenu = 'Debug';
   }
 
   /**
@@ -288,7 +292,7 @@ class SimulatorXcode8 extends SimulatorXcode7 {
     const locationSetters = [
       async () => await setLocationWithLyft(this.udid, latitude, longitude),
       async () => await setLocationWithIdb(this.idb, latitude, longitude),
-      async () => await setLocationWithAppleScript(this, latitude, longitude)
+      async () => await setLocationWithAppleScript(this, latitude, longitude, this._locationMenu),
     ];
 
     let lastError;


### PR DESCRIPTION
The iOS simulator menu bar now (as of Xcode 11.4) has a "Features" menu, and the "Location" menu item has been moved into it. So add the ability to specify what the menu is in order to make AppleScript geolocation setting work again.

Up to Xcode 11.4:
<img width="865" alt="Screenshot 2020-03-10 11 07 13" src="https://user-images.githubusercontent.com/2614354/76326927-b7ca8580-62bf-11ea-93c4-723d75a43159.png">

Xcode 11.4:
<img width="826" alt="Screenshot 2020-03-10 11 09 29" src="https://user-images.githubusercontent.com/2614354/76326942-bb5e0c80-62bf-11ea-9233-34566555055f.png">

With this the entire "basic" test suite from `appium-xcuitest-driver` successfully runs with Xcode 11.4 beta 3.