### PR TITLE
fix: Fix handling of the native media library permission

### DIFF
--- a/lib/simulator-xcode-11.4.js
+++ b/lib/simulator-xcode-11.4.js
@@ -137,18 +137,16 @@ class SimulatorXcode11_4 extends SimulatorXcode11 {
       JSON.stringify(permissionsMapping, null, 2));
     const nonNativePerms = {};
     for (let [permName, access] of _.toPairs(permissionsMapping)) {
-      if (!NATIVE_SIMCTL_PERMISSIONS.includes(permName)) {
+      if (permName === 'medialibrary') {
+        permName = 'media-library';
+      } else if (permName === 'location' && _.toLower(access) === 'always') {
+        permName = 'location-always';
+      } else if (!NATIVE_SIMCTL_PERMISSIONS.includes(permName)) {
         nonNativePerms[permName] = access;
         continue;
       }
 
-      access = _.toLower(access);
-      if (permName === 'medialibrary') {
-        permName = 'media-library';
-      } else if (permName === 'location' && access === 'always') {
-        permName = 'location-always';
-      }
-      switch (access) {
+      switch (_.toLower(access)) {
         case 'yes':
         case 'inuse':
         case 'always':


### PR DESCRIPTION
In the previous implementation the order of checks was incorrect, so, for example, the 'medialibrary' permission was always recognised as non-native instead of being transformed to `media-library`