### PR TITLE
refactor: Prefer own implementation of app activation over idb one

### DIFF
--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import AsyncLock from 'async-lock';
 import {
   killAllSimulators, safeRimRaf, getDeveloperRoot,
-  installSSLCert, hasSSLCert,
+  installSSLCert, hasSSLCert, activateApp,
 } from './utils.js';
 import { asyncmap, retryInterval, waitForCondition, retry } from 'asyncbox';
 import * as settings from './settings';
@@ -1033,6 +1033,14 @@ class SimulatorXcode6 extends EventEmitter {
    * itself and return nothing.
    */
   async _activateWindow () { // eslint-disable-line require-await
+    const pid = await this.getUIClientPid();
+    if (pid) {
+      try {
+        return await activateApp(pid);
+      } catch (e) {
+        log.debug(e.stderr || e.message);
+      }
+    }
     return `
       tell application "System Events"
         tell process "Simulator"

--- a/lib/simulator-xcode-8.js
+++ b/lib/simulator-xcode-8.js
@@ -218,19 +218,6 @@ class SimulatorXcode8 extends SimulatorXcode7 {
   /**
    * @inheritdoc
    * @override
-   * @private
-   */
-  async _activateWindow () {
-    if (this.idb) {
-      return await this.idb.focusSimulator();
-    }
-    log.warn(`Cannot focus Simulator window with idb. Defaulting to AppleScript`);
-    return await super._activateWindow();
-  }
-
-  /**
-   * @inheritdoc
-   * @override
    */
   async isBiometricEnrolled () {
     const output = await this.executeUIClientScript(`

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -281,17 +281,31 @@ class SimulatorXcode9 extends SimulatorXcode8 {
    * @private
    */
   async _activateWindow () {
-    if (this.idb) {
-      return await this.idb.focusSimulator();
+    let selfName;
+    let selfSdk;
+    let bootedDevicesCount = 0;
+    for (const [sdk, deviceArr] of _.toPairs(await this.simctl.getDevices())) {
+      for (const {state, udid, name} of deviceArr) {
+        if (state === 'Booted') {
+          bootedDevicesCount++;
+        }
+        if (!selfName && udid === this.udid) {
+          selfSdk = sdk;
+          selfName = name;
+        }
+      }
     }
-    log.warn(`Cannot focus Simulator window with idb. Defaulting to AppleScript`);
-    const {name, sdk} = await this.stat();
+    if (bootedDevicesCount < 2) {
+      return await super._activateWindow();
+    }
+
+    // There are potentially more that one Simulator window
     return `
       tell application "System Events"
         tell process "Simulator"
           set frontmost to false
           set frontmost to true
-          click (menu item 1 where (its name contains "${name} " and its name contains "${sdk}")) of menu 1 of menu bar item "Window" of menu bar 1
+          click (menu item 1 where (its name contains "${selfName} " and its name contains "${selfSdk}")) of menu 1 of menu bar item "Window" of menu bar 1
         end tell
       end tell
     `;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -306,7 +306,7 @@ async function getDeveloperRoot () {
  * See https://developer.apple.com/documentation/appkit/nsrunningapplication/1528725-activatewithoptions?language=objc
  * for more details.
  *
- * @param {number|string} pid App identifier
+ * @param {number|string} pid App process identifier
  * @throws {Error} If the given PID is not running or there was a failure
  * while activating the app
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ import { exec } from 'teen_process';
 import { waitForCondition } from 'asyncbox';
 import { getVersion } from 'appium-xcode';
 import Simctl from 'node-simctl';
-import { fs, tempDir } from 'appium-support';
+import { fs, tempDir, util } from 'appium-support';
 import { Certificate } from './certificate';
 import path from 'path';
 import Simulator from './simulator-xcode-6';
@@ -14,6 +14,18 @@ import fkill from 'fkill';
 const DEFAULT_SIM_SHUTDOWN_TIMEOUT = 30000;
 const SAFARI_STARTUP_TIMEOUT = 25 * 1000;
 const MOBILE_SAFARI_BUNDLE_ID = 'com.apple.mobilesafari';
+const APP_ACTIVATION_SCRIPT = (pid) => `#!/usr/bin/python
+
+from AppKit import NSApplicationActivateIgnoringOtherApps, NSApplicationActivateAllWindows
+from Cocoa import NSRunningApplication
+
+app = NSRunningApplication.runningApplicationWithProcessIdentifier_(${pid})
+if not app:
+    raise ValueError('App with PID ${pid} is not running')
+if not app.activateWithOptions_(NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps):
+    raise ValueError('App with PID ${pid} cannot be activated')
+`;
+
 
 const BIOMETRICS = {
   touchId: 'fingerTouch',
@@ -289,6 +301,28 @@ async function getDeveloperRoot () {
   return stdout.trim();
 }
 
+/**
+ * Activates the app having the given process identifier.
+ * See https://developer.apple.com/documentation/appkit/nsrunningapplication/1528725-activatewithoptions?language=objc
+ * for more details.
+ *
+ * @param {number|string} pid App identifier
+ * @throws {Error} If the given PID is not running or there was a failure
+ * while activating the app
+ */
+async function activateApp (pid) {
+  const tmpScript = await tempDir.path({
+    prefix: `activate_sim_${util.uuidV4().substring(0, 8)}`,
+    suffix: '.py',
+  });
+  await fs.writeFile(tmpScript, APP_ACTIVATION_SCRIPT(pid), 'utf8');
+  try {
+    await exec('/usr/bin/python', [tmpScript]);
+  } finally {
+    await fs.rimraf(tmpScript);
+  }
+}
+
 export {
   killAllSimulators,
   endAllSimulatorDaemons,
@@ -301,6 +335,7 @@ export {
   execSQLiteQuery,
   toBiometricDomainComponent,
   getDeveloperRoot,
+  activateApp,
   SAFARI_STARTUP_TIMEOUT,
   MOBILE_SAFARI_BUNDLE_ID,
 };


### PR DESCRIPTION
I've checked how `focus` command is implemented in idb code and ported it to PyObjC