### PR TITLE
fix: sim window minized on xcode 11.4

### DIFF
--- a/lib/simulator-xcode-11.4.js
+++ b/lib/simulator-xcode-11.4.js
@@ -114,9 +114,8 @@ class SimulatorXcode11_4 extends SimulatorXcode11 {
     if (!isUiClientRunning) {
       await this.startUIClient(opts);
     }
-    await this.bootSimulator();
+    await this.boot();
   }
-
 
 }
 

--- a/lib/simulator-xcode-11.4.js
+++ b/lib/simulator-xcode-11.4.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import SimulatorXcode11 from './simulator-xcode-11';
 import log from './logger';
+import {retryInterval} from "asyncbox";
 
 
 class SimulatorXcode11_4 extends SimulatorXcode11 {
@@ -107,22 +108,18 @@ class SimulatorXcode11_4 extends SimulatorXcode11 {
   }
 
   /**
-   * Opens simulator's UI Client if not already open and boots sim
-   *
-   * @param uiClientPid - process id of simulator UI client.
-   * @param opts - arguments to start simulator UI client with.
-   * @returns {Promise} - a promise that resolves when sim UI client is launched and sim is booted.
+   * @inheritdoc
    * @override
-   */
-  async launchSimWindow (uiClientPid, opts) {
+   * */
+  async launchWindow (isUiClientRunning, opts) {
     // In xcode 11.4, UI Client must be first launched, otherwise
     // sim window stays minimized
-    if (!uiClientPid) {
+    if (!isUiClientRunning) {
       await this.startUIClient(opts);
     }
-    log.info(`Booting Simulator with UDID '${this.udid}'...`);
     await this.bootSimulator();
   }
+
 
 }
 

--- a/lib/simulator-xcode-11.4.js
+++ b/lib/simulator-xcode-11.4.js
@@ -1,8 +1,5 @@
 import _ from 'lodash';
 import SimulatorXcode11 from './simulator-xcode-11';
-import log from './logger';
-import {retryInterval} from "asyncbox";
-
 
 class SimulatorXcode11_4 extends SimulatorXcode11 {
   constructor (udid, xcodeVersion) {

--- a/lib/simulator-xcode-11.4.js
+++ b/lib/simulator-xcode-11.4.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import SimulatorXcode11 from './simulator-xcode-11';
+import log from './logger';
 
 
 class SimulatorXcode11_4 extends SimulatorXcode11 {
@@ -104,6 +105,25 @@ class SimulatorXcode11_4 extends SimulatorXcode11 {
   async clearKeychains () {
     await this.simctl.resetKeychain();
   }
+
+  /**
+   * Opens simulator's UI Client if not already open and boots sim
+   *
+   * @param uiClientPid - process id of simulator UI client.
+   * @param opts - arguments to start simulator UI client with.
+   * @returns {Promise} - a promise that resolves when sim UI client is launched and sim is booted.
+   * @override
+   */
+  async launchSimWindow (uiClientPid, opts) {
+    // In xcode 11.4, UI Client must be first launched, otherwise
+    // sim window stays minimized
+    if (!uiClientPid) {
+      await this.startUIClient(opts);
+    }
+    log.info(`Booting Simulator with UDID '${this.udid}'...`);
+    await this.bootSimulator();
+  }
+
 }
 
 export default SimulatorXcode11_4;

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -138,7 +138,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
           }
           await waitForShutdown();
         }
-        await this.launchSimWindow(uiClientPid, opts);
+        await this.launchWindow(uiClientPid, opts);
       }
       return true;
     });
@@ -152,28 +152,31 @@ class SimulatorXcode9 extends SimulatorXcode8 {
   /***
    * Boots simulator and opens simulators UI Client if not already opened.
    *
-   * @param uiClientPid - process id of simulator UI client.
-   * @param opts - arguments to start simulator UI client with.
-   * @returns {Promise} - a promise that resolves when sim is booted and sim UI client is launched.
+   * @param {?String} isUiClientRunning - process id of simulator UI client.
+   * @param {Object} opts - arguments to start simulator UI client with.
    */
-  async launchSimWindow (uiClientPid, opts) {
-    log.info(`Booting Simulator with UDID '${this.udid}'...`);
+  async launchWindow (isUiClientRunning, opts) {
     await this.bootSimulator();
-    if (!uiClientPid) {
+    if (!isUiClientRunning) {
       await this.startUIClient(opts);
     }
   }
 
   /**
-   * Boots simulator.
-   *
-   * @returns {Promise} - A promise that resolved when simulator is booted.
+   * Boots simulator if not already booted.
    */
   async bootSimulator () {
-    try {
-      await retryInterval(3, 2000, async () => await this.simctl.bootDevice());
-    } catch (err) {
-      log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero exit code`);
+    const {state: serverState} = await this.stat();
+    if (serverState === 'Booted') {
+      log.info(`Simulator with UDID '${this.udid}' is already running`);
+      return false;
+    } else {
+      try {
+        log.info(`Booting Simulator with UDID '${this.udid}'...`);
+        await retryInterval(3, 2000, async () => await this.simctl.bootDevice());
+      } catch (err) {
+        log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero exit code`);
+      }
     }
   }
 

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -86,13 +86,6 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     if (!_.isEmpty(opts.devicePreferences) || !_.isEmpty(commonPreferences)) {
       await this.updatePreferences(opts.devicePreferences, commonPreferences);
     }
-    const bootSimulator = async () => {
-      try {
-        await retryInterval(3, 2000, async () => await this.simctl.bootDevice());
-      } catch (err) {
-        log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero exit code`);
-      }
-    };
     const waitForShutdown = async (waitMs = SIMULATOR_SHUTDOWN_TIMEOUT) => {
       try {
         await waitForCondition(async () => {
@@ -128,7 +121,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
           return false;
         }
         log.info(`Booting Simulator with UDID '${this.udid}' in headless mode. All UI-related capabilities are going to be ignored`);
-        await bootSimulator();
+        await this.bootSimulator();
       } else {
         if (isServerRunning && uiClientPid) {
           log.info(`Both Simulator with UDID '${this.udid}' and the UI client are currently running`);
@@ -145,11 +138,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
           }
           await waitForShutdown();
         }
-        log.info(`Booting Simulator with UDID '${this.udid}'...`);
-        await bootSimulator();
-        if (!uiClientPid) {
-          await this.startUIClient(opts);
-        }
+        await this.launchSimWindow(uiClientPid, opts);
       }
       return true;
     });
@@ -157,6 +146,34 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     if (shouldWaitForBoot) {
       await this.waitForBoot(opts.startupTimeout);
       log.info(`Simulator with UDID ${this.udid} booted in ${timer.getDuration().asSeconds.toFixed(3)}s`);
+    }
+  }
+
+  /***
+   * Boots simulator and opens simulators UI Client if not already opened.
+   *
+   * @param uiClientPid - process id of simulator UI client.
+   * @param opts - arguments to start simulator UI client with.
+   * @returns {Promise} - a promise that resolves when sim is booted and sim UI client is launched.
+   */
+  async launchSimWindow (uiClientPid, opts) {
+    log.info(`Booting Simulator with UDID '${this.udid}'...`);
+    await this.bootSimulator();
+    if (!uiClientPid) {
+      await this.startUIClient(opts);
+    }
+  }
+
+  /**
+   * Boots simulator.
+   *
+   * @returns {Promise} - A promise that resolved when simulator is booted.
+   */
+  async bootSimulator () {
+    try {
+      await retryInterval(3, 2000, async () => await this.simctl.bootDevice());
+    } catch (err) {
+      log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero exit code`);
     }
   }
 

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -121,7 +121,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
           return false;
         }
         log.info(`Booting Simulator with UDID '${this.udid}' in headless mode. All UI-related capabilities are going to be ignored`);
-        await this.bootSimulator();
+        await this.boot();
       } else {
         if (isServerRunning && uiClientPid) {
           log.info(`Both Simulator with UDID '${this.udid}' and the UI client are currently running`);
@@ -152,11 +152,11 @@ class SimulatorXcode9 extends SimulatorXcode8 {
   /***
    * Boots simulator and opens simulators UI Client if not already opened.
    *
-   * @param {?String} isUiClientRunning - process id of simulator UI client.
-   * @param {Object} opts - arguments to start simulator UI client with.
+   * @param {boolean} isUiClientRunning - process id of simulator UI client.
+   * @param {RunOptions} opts - arguments to start simulator UI client with.
    */
-  async launchWindow (isUiClientRunning, opts) {
-    await this.bootSimulator();
+  async launchWindow (isUiClientRunning, opts = {}) {
+    await this.boot();
     if (!isUiClientRunning) {
       await this.startUIClient(opts);
     }
@@ -165,7 +165,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
   /**
    * Boots simulator if not already booted.
    */
-  async bootSimulator () {
+  async boot () {
     log.info(`Booting Simulator with UDID '${this.udid}'...`);
     try {
       await retryInterval(3, 2000, async () => {

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -177,7 +177,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
           }
           log.debug(`Simulator with UDID '${this.udid}' is already in Booted state`);
         }
-      };
+      });
     } catch (err) {
       log.warn(err.stderr || err.message);
     }

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -166,17 +166,20 @@ class SimulatorXcode9 extends SimulatorXcode8 {
    * Boots simulator if not already booted.
    */
   async bootSimulator () {
-    const {state: serverState} = await this.stat();
-    if (serverState === 'Booted') {
-      log.info(`Simulator with UDID '${this.udid}' is already running`);
-      return false;
-    } else {
-      try {
-        log.info(`Booting Simulator with UDID '${this.udid}'...`);
-        await retryInterval(3, 2000, async () => await this.simctl.bootDevice());
-      } catch (err) {
-        log.warn(`'xcrun simctl boot ${this.udid}' command has returned non-zero exit code`);
-      }
+    log.info(`Booting Simulator with UDID '${this.udid}'...`);
+    try {
+      await retryInterval(3, 2000, async () => {
+        try {
+          await this.simctl.bootDevice();
+        } catch (e) {
+          if (!_.includes(e.stderr, 'Unable to boot device in current state: Booted')) {
+            throw e;
+          }
+          log.debug(`Simulator with UDID '${this.udid}' is already in Booted state`);
+        }
+      };
+    } catch (err) {
+      log.warn(err.stderr || err.message);
     }
   }
 


### PR DESCRIPTION
Simulators remain minimized when running tests with Xcode 11.4.1. Fix was to launch simulator UI client before simulators are booted. 