### PR TITLE
fix: use simctl privacy for calendar access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,9 @@ language: node_js
 node_js: "10"
 matrix:
   include:
-    - osx_image: xcode7.3
-      env: DEVICE=9.3
-
-    - osx_image: xcode8.3
-      env: DEVICE=9.3
-    - osx_image: xcode8.3
-      env: DEVICE=10.3
-
-    - osx_image: xcode9.3
-      env: DEVICE=10.3
     - osx_image: xcode9.3
       env: DEVICE=11.3
 
-    # TODO: uncomment once Travis 9.4 VMs have iOS 11.3 SDK installed
-    # - osx_image: xcode9.4
-    #   env: DEVICE=11.3
     - osx_image: xcode9.4
       env: DEVICE=11.4
 
@@ -32,12 +19,10 @@ matrix:
 before_install:
   # brew update is not necessary on new brew versions, but some Travis
   # images have v1.x, which does not auto-update
-  - if [ ${TRAVIS_OSX_IMAGE} != "xcode7.3" ]; then
-      brew update;
-      brew --version;
-      brew tap wix/brew;
-      brew install applesimutils;
-    fi
+  brew update;
+  brew --version;
+  brew tap wix/brew;
+  brew install applesimutils;
 install:
   - npm install
 script:

--- a/lib/simulator-xcode-11.4.js
+++ b/lib/simulator-xcode-11.4.js
@@ -117,6 +117,23 @@ class SimulatorXcode11_4 extends SimulatorXcode11 {
     await this.boot();
   }
 
+  /**
+   * @inheritdoc
+   * @override
+   */
+  async enableCalendarAccess (bundleID) {
+    await this.simctl.grantPermission(bundleID, 'calendar');
+  }
+
+  /**
+   * @inheritdoc
+   * @override
+   */
+  async disableCalendarAccess (bundleID) {
+    await this.simctl.revokePermission(bundleID, 'calendar');
+  }
+
+
 }
 
 export default SimulatorXcode11_4;

--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -57,6 +57,14 @@ async function getSimulator (udid, opts = {}) {
            `with udid '${udid}'`);
   let SimClass;
   switch (xcodeVersion.major) {
+    // Early, unsupported Xcodes
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 5:
+      handleUnsupportedXcode(xcodeVersion);
+      break;
     case 6:
       SimClass = SimulatorXcode6;
       break;
@@ -81,15 +89,14 @@ async function getSimulator (udid, opts = {}) {
       SimClass = SimulatorXcode10;
       break;
     case 11:
-      if (xcodeVersion.minor >= 4) {
+    case 12:
+    default:
+      if (xcodeVersion.major > 11 || xcodeVersion.minor >= 4) {
         SimClass = SimulatorXcode11_4;
       } else {
         SimClass = SimulatorXcode11;
       }
       break;
-    default:
-      handleUnsupportedXcode(xcodeVersion);
-      SimClass = SimulatorXcode10;
   }
 
   return new SimClass(udid, xcodeVersion);

--- a/test/unit/simulator-specs.js
+++ b/test/unit/simulator-specs.js
@@ -56,7 +56,7 @@ describe('simulator', function () {
       [10, 0, '10.0.0', SimulatorXcode10],
       [11, 0, '11.0.0', SimulatorXcode11],
       [11, 4, '11.4.0', SimulatorXcode11_4],
-      [Infinity, 0, '100000000.0.0', SimulatorXcode11_4],
+      [Number.MAX_VALUE, 0, `${Number.MAX_VALUE}.0.0`, SimulatorXcode11_4],
     ];
 
     for (const [major, minor, versionString, expectedXcodeClass] of xcodeVersions) {

--- a/test/unit/simulator-specs.js
+++ b/test/unit/simulator-specs.js
@@ -1,8 +1,6 @@
 // transpile:mocha
 
 import { getSimulator, getDeviceString } from '../..';
-import SimulatorXcode6 from '../../lib/simulator-xcode-6';
-import SimulatorXcode7 from '../../lib/simulator-xcode-7';
 import Simctl from 'node-simctl';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -10,6 +8,14 @@ import sinon from 'sinon';
 import { devices } from '../assets/deviceList';
 import B from 'bluebird';
 import xcode from 'appium-xcode';
+import SimulatorXcode6 from '../../lib/simulator-xcode-6';
+import SimulatorXcode7 from '../../lib/simulator-xcode-7';
+import SimulatorXcode8 from '../../lib/simulator-xcode-8';
+import SimulatorXcode9 from '../../lib/simulator-xcode-9';
+import SimulatorXcode93 from '../../lib/simulator-xcode-9.3';
+import SimulatorXcode10 from '../../lib/simulator-xcode-10';
+import SimulatorXcode11 from '../../lib/simulator-xcode-11';
+import SimulatorXcode11_4 from '../../lib/simulator-xcode-11.4';
 
 
 chai.should();
@@ -41,19 +47,31 @@ describe('simulator', function () {
       sim.should.be.an.instanceof(SimulatorXcode6);
     });
 
-    it('should create an xcode 7 simulator with xcode version 7', async function () {
-      let xcodeVersion = {major: 7, versionString: '7.0.0'};
-      xcodeMock.expects('getVersion').returns(B.resolve(xcodeVersion));
+    const xcodeVersions = [
+      [6, 0, '6.0.0', SimulatorXcode6],
+      [7, 0, '7.0.0', SimulatorXcode7],
+      [8, 0, '8.0.0', SimulatorXcode8],
+      [9, 0, '9.0.0', SimulatorXcode9],
+      [9, 3, '9.3.0', SimulatorXcode93],
+      [10, 0, '10.0.0', SimulatorXcode10],
+      [11, 0, '11.0.0', SimulatorXcode11],
+      [11, 4, '11.4.0', SimulatorXcode11_4],
+      [Infinity, 0, '100000000.0.0', SimulatorXcode11_4],
+    ];
 
-      let sim = await getSimulator(UDID);
-      sim.xcodeVersion.should.equal(xcodeVersion);
-      sim.should.be.an.instanceof(SimulatorXcode7);
-    });
+    for (const [major, minor, versionString, expectedXcodeClass] of xcodeVersions) {
+      it(`should create an xcode ${major} simulator with xcode version ${versionString}`, async function () {
+        let xcodeVersion = {major, minor, versionString};
+        xcodeMock.expects('getVersion').returns(B.resolve(xcodeVersion));
+        let sim = await getSimulator(UDID);
+        sim.xcodeVersion.should.equal(xcodeVersion);
+        sim.should.be.an.instanceof(expectedXcodeClass);
+      });
+    }
 
     it('should throw an error if xcode version less than 6', async function () {
       let xcodeVersion = {major: 5, versionString: '5.4.0'};
       xcodeMock.expects('getVersion').returns(B.resolve(xcodeVersion));
-
       await getSimulator(UDID).should.eventually.be.rejectedWith('version');
     });
 


### PR DESCRIPTION
Makes a call to `xcrun simctl privacy...` instead of directly editing TCC.db to grant calendar access.

Also changes the simulator.js logic so 
1. it explicitly throws an error if Xcode versions 1 ~> 5 are provided.
2. if anything >= 11.4 is provided, it will default to `simulator-xcode-11.4` implementation

_WHY?_ So that when Xcode 13 comes out it will, by default, use the latest Xcode implementation. And if it works (ie: our e2e tests keep passing) we don't need to do anything

(depends on https://github.com/appium/node-simctl/pull/114 ... make sure to publish this first and bump up min node-simctl before merging)