### PR TITLE
fix: Use system-wide decimal separator in the location script

### DIFF
--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -70,10 +70,10 @@ async function setLocationWithIdb (idb, latitude, longitude) {
  * @throws {Error} If it failed to set the location
  */
 async function setLocationWithAppleScript (sim, latitude, longitude, menu = 'Debug') {
-  const decimalPoint = (0.1).toLocaleString().replace(/\d/g, '');
+  const decimalSeparator = (0.1).toLocaleString().replace(/\d/g, '');
   // Make sure system-wide decimal separator is used
-  const latitudeStr = `${latitude}`.replace(/\D/g, decimalPoint);
-  const longitudeStr = `${longitude}`.replace(/\D/g, decimalPoint);
+  const latitudeStr = `${latitude}`.replace(/\D/g, decimalSeparator);
+  const longitudeStr = `${longitude}`.replace(/\D/g, decimalSeparator);
   const output = await sim.executeUIClientScript(`
     tell application "System Events"
       tell process "Simulator"

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -70,6 +70,10 @@ async function setLocationWithIdb (idb, latitude, longitude) {
  * @throws {Error} If it failed to set the location
  */
 async function setLocationWithAppleScript (sim, latitude, longitude, menu = 'Debug') {
+  const decimalPoint = (0.1).toLocaleString().replace(/\d/g, '');
+  // Make sure system-wide decimal separator is used
+  const latitudeStr = `${latitude}`.replace(/\D/g, decimalPoint);
+  const longitudeStr = `${longitude}`.replace(/\D/g, decimalPoint);
   const output = await sim.executeUIClientScript(`
     tell application "System Events"
       tell process "Simulator"
@@ -77,9 +81,9 @@ async function setLocationWithAppleScript (sim, latitude, longitude, menu = 'Deb
         set dstMenuItem to menu item (featureName & "…") of menu 1 of menu item "Location" of menu 1 of menu bar item "${menu}" of menu bar 1
         click dstMenuItem
         delay 1
-        set value of text field 1 of window featureName to ${latitude} as string
+        set value of text field 1 of window featureName to "${latitudeStr}"
         delay 0.5
-        set value of text field 2 of window featureName to ${longitude} as string
+        set value of text field 2 of window featureName to "${longitudeStr}"
         delay 0.5
         click button "OK" of window featureName
         delay 0.5


### PR DESCRIPTION
Simulator UI does not accept values if a wrong decimal separator is used.
cc @wswebcreation