### PR TITLE
fix: Update simulator preferences handling

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,10 +19,10 @@ parameters:
     xcodeVersion: 10.3
     iosDeviceName: iPhone X
     vmImage: macOS-10.14
-  # - iosVersion: 13
-  #   xcodeVersion: 11
-  #   iosDeviceName: iPhone 11
-  #   vmImage: macOS-10.15
+  - iosVersion: 13.2
+    xcodeVersion: 11.2
+    iosDeviceName: iPhone 11
+    vmImage: macOS-10.15
   - iosVersion: 13.7
     xcodeVersion: 11.7
     iosDeviceName: iPhone 11

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,10 +19,10 @@ parameters:
     xcodeVersion: 10.3
     iosDeviceName: iPhone X
     vmImage: macOS-10.14
-  - iosVersion: 13
-    xcodeVersion: 11
-    iosDeviceName: iPhone 11
-    vmImage: macOS-10.15
+  # - iosVersion: 13
+  #   xcodeVersion: 11
+  #   iosDeviceName: iPhone 11
+  #   vmImage: macOS-10.15
   - iosVersion: 13.7
     xcodeVersion: 11.7
     iosDeviceName: iPhone 11

--- a/azure-templates/base_unit_test_job.yml
+++ b/azure-templates/base_unit_test_job.yml
@@ -14,6 +14,8 @@ jobs:
     - task: NodeTool@0
       inputs:
         versionSpec: "$(DEFAULT_NODE_VERSION)"
+    - script: ls /Applications
+      displayName: List Apps
     - script: sudo xcode-select --switch "/Applications/Xcode_$(XCODE_VERSION).app/Contents/Developer"
       displayName: Prepare Env
     - script: xcrun simctl list

--- a/lib/defaults-utils.js
+++ b/lib/defaults-utils.js
@@ -1,0 +1,145 @@
+import _ from 'lodash';
+import { DOMParser, XMLSerializer } from 'xmldom';
+import { exec } from 'teen_process';
+import B from 'bluebird';
+
+/**
+ * Serializes the given value to plist-compatible
+ * XML representation, which is ready for further usage
+ * as `defaults` argument
+ *
+ * @param {*} value The value to be serialized
+ * @param {boolean} serialize [true] Whether to serialize the resulting
+ * XML to string or to return raw ChildNode instance
+ * @returns {ChildNode|string} Either string or raw node representation of
+ * the given value
+ */
+function toXmlArg (value, serialize = true) {
+  let xmlDoc = null;
+
+  if (_.isPlainObject(value)) {
+    xmlDoc = new DOMParser().parseFromString('<dict></dict>', 'text/xml');
+    for (const [subKey, subValue] of _.toPairs(value)) {
+      const keyEl = xmlDoc.createElement('key');
+      const keyTextEl = xmlDoc.createTextNode(subKey);
+      keyEl.appendChild(keyTextEl);
+      xmlDoc.documentElement.appendChild(keyEl);
+      const subValueEl = xmlDoc.importNode(toXmlArg(subValue, false), true);
+      xmlDoc.documentElement.appendChild(subValueEl);
+    }
+  } else if (_.isArray(value)) {
+    xmlDoc = new DOMParser().parseFromString('<array></array>', 'text/xml');
+    for (const subValue of value) {
+      const subValueEl = xmlDoc.importNode(toXmlArg(subValue, false), true);
+      xmlDoc.documentElement.appendChild(subValueEl);
+    }
+  } else if (_.isBoolean(value)) {
+    xmlDoc = new DOMParser().parseFromString(value ? '<true/>' : '<false/>', 'text/xml');
+  } else if (_.isInteger(value)) {
+    xmlDoc = new DOMParser().parseFromString(`<integer>${value}</integer>`, 'text/xml');
+  } else if (_.isNumber(value)) {
+    xmlDoc = new DOMParser().parseFromString(`<real>${value}</real>`, 'text/xml');
+  } else if (_.isString(value)) {
+    xmlDoc = new DOMParser().parseFromString(`<string></string>`, 'text/xml');
+    const valueTextEl = xmlDoc.createTextNode(value);
+    xmlDoc.documentElement.appendChild(valueTextEl);
+  }
+
+  if (!xmlDoc) {
+    throw TypeError(`The defaults value ${JSON.stringify(value)} cannot be written, ` +
+      `because it is not known how to handle its type`);
+  }
+
+  return serialize
+    ? new XMLSerializer().serializeToString(xmlDoc.documentElement)
+    : xmlDoc.documentElement;
+}
+
+
+/**
+ * Generates command line args for the `defaults`
+ * command line utility for preferences update.
+ * See https://shadowfile.inode.link/blog/2018/06/advanced-defaults1-usage/
+ * for more details.
+ *
+ * @param {Object} valuesMap Preferences mapping
+ * @returns {Array<Array<string>>} Each item in the array
+ * is the `defaults write <plist>` command suffix
+ */
+function generateUpdateCommandArgs (valuesMap) {
+  const resultArgs = [];
+  for (const [key, value] of _.toPairs(valuesMap)) {
+    if (_.isPlainObject(value)) {
+      const dictArgs = [key, '-dict-add'];
+      for (const [subKey, subValue] of _.toPairs(value)) {
+        dictArgs.push(subKey, toXmlArg(subValue));
+      }
+      resultArgs.push(dictArgs);
+    } else if (_.isArray(value)) {
+      const arrayArgs = [key, '-array-add'];
+      for (const subValue of arrayArgs) {
+        arrayArgs.push(toXmlArg(subValue));
+      }
+      resultArgs.push(arrayArgs);
+    } else {
+      resultArgs.push([key, toXmlArg(value)]);
+    }
+  }
+  return resultArgs;
+}
+
+
+class NSUserDefaults {
+  constructor (plist) {
+    this.plist = plist;
+  }
+
+  /**
+   * Reads the content of the given plist file using plutil command line tool
+   * and serializes it to a string
+   *
+   * @returns {string} The serialized plist content
+   * @throws {Error} If there was an error during serialization
+   */
+  async readToXml () {
+    let stdout;
+    try {
+      ({stdout} = await exec('plutil', ['-convert', 'xml1', '-o', '-', this.plist]));
+    } catch (e) {
+      throw new Error(`'${this.plist}' cannot be converted to XML. Original error: ${e.stderr || e.message}`);
+    }
+    return new DOMParser().parseFromString(stdout);
+  }
+
+  /**
+   * Updates the content of the given plist file.
+   * If the plist does not exist yet then it is going to be created.
+   *
+   * @param {Object} valuesMap Mapping of values to update.
+   * If the value is of dictionary type then only the first level dictionary gets
+   * updated. Everything below this level will be overridden. This is known `defaults`
+   * tool limitation.
+   * @throws {Error} If there was an error while updating the plist
+   */
+  async update (valuesMap) {
+    if (!_.isPlainObject(valuesMap)) {
+      throw new TypeError(`plist values must be a map. '${valuesMap}' is given instead`);
+    }
+    if (_.isEmpty(valuesMap)) {
+      return;
+    }
+
+    const commandArgs = generateUpdateCommandArgs();
+    try {
+      await B.all(commandArgs.map((args) => exec('defaults', ['write', this.plist, ...args])));
+    } catch (e) {
+      throw new Error(`Could not write defaults into '${this.plist}'. Original error: ${e.stderr || e.message}`);
+    }
+  }
+}
+
+
+export {
+  NSUserDefaults,
+  toXmlArg, generateUpdateCommandArgs,
+};

--- a/lib/defaults-utils.js
+++ b/lib/defaults-utils.js
@@ -11,7 +11,7 @@ import log from './logger';
  *
  * @param {*} value The value to be serialized
  * @param {boolean} serialize [true] Whether to serialize the resulting
- * XML to string or to return raw ChildNode instance
+ * XML to string or to return raw HTMLElement instance
  * @returns {HTMLElement|string} Either string or raw node representation of
  * the given value
  * @throws {TypeError} If it is not known how to serialize the given value
@@ -57,10 +57,9 @@ function toXmlArg (value, serialize = true) {
     : xmlDoc.documentElement;
 }
 
-
 /**
  * Generates command line args for the `defaults`
- * command line utility for preferences update.
+ * command line utility based on the given preference values mapping.
  * See https://shadowfile.inode.link/blog/2018/06/advanced-defaults1-usage/
  * for more details.
  *
@@ -124,10 +123,11 @@ class NSUserDefaults {
    * Updates the content of the given plist file.
    * If the plist does not exist yet then it is going to be created.
    *
-   * @param {Object} valuesMap Mapping of values to update.
-   * If the value is of dictionary type then only the first level dictionary gets
+   * @param {Object} valuesMap Mapping of preference values to update.
+   * If any of item values are of dictionary type then only the first level dictionary gets
    * updated. Everything below this level will be replaced. This is the known limitation
-   * if the `defaults` command line tool.
+   * of the `defaults` command line tool. A workaround for it would be to read the current
+   * preferences mapping first and merge it with this value.
    * @throws {Error} If there was an error while updating the plist
    */
   async update (valuesMap) {

--- a/lib/defaults-utils.js
+++ b/lib/defaults-utils.js
@@ -2,17 +2,19 @@ import _ from 'lodash';
 import { DOMParser, XMLSerializer } from 'xmldom';
 import { exec } from 'teen_process';
 import B from 'bluebird';
+import log from './logger';
 
 /**
  * Serializes the given value to plist-compatible
  * XML representation, which is ready for further usage
- * as `defaults` argument
+ * with `defaults` command line tool arguments
  *
  * @param {*} value The value to be serialized
  * @param {boolean} serialize [true] Whether to serialize the resulting
  * XML to string or to return raw ChildNode instance
- * @returns {ChildNode|string} Either string or raw node representation of
+ * @returns {HTMLElement|string} Either string or raw node representation of
  * the given value
+ * @throws {TypeError} If it is not known how to serialize the given value
  */
 function toXmlArg (value, serialize = true) {
   let xmlDoc = null;
@@ -46,7 +48,7 @@ function toXmlArg (value, serialize = true) {
   }
 
   if (!xmlDoc) {
-    throw TypeError(`The defaults value ${JSON.stringify(value)} cannot be written, ` +
+    throw new TypeError(`The defaults value ${JSON.stringify(value)} cannot be written, ` +
       `because it is not known how to handle its type`);
   }
 
@@ -69,20 +71,28 @@ function toXmlArg (value, serialize = true) {
 function generateUpdateCommandArgs (valuesMap) {
   const resultArgs = [];
   for (const [key, value] of _.toPairs(valuesMap)) {
-    if (_.isPlainObject(value)) {
-      const dictArgs = [key, '-dict-add'];
-      for (const [subKey, subValue] of _.toPairs(value)) {
-        dictArgs.push(subKey, toXmlArg(subValue));
+    try {
+      if (_.isPlainObject(value)) {
+        const dictArgs = [key, '-dict-add'];
+        for (const [subKey, subValue] of _.toPairs(value)) {
+          dictArgs.push(subKey, toXmlArg(subValue));
+        }
+        resultArgs.push(dictArgs);
+      } else if (_.isArray(value)) {
+        const arrayArgs = [key, '-array-add'];
+        for (const subValue of arrayArgs) {
+          arrayArgs.push(toXmlArg(subValue));
+        }
+        resultArgs.push(arrayArgs);
+      } else {
+        resultArgs.push([key, toXmlArg(value)]);
       }
-      resultArgs.push(dictArgs);
-    } else if (_.isArray(value)) {
-      const arrayArgs = [key, '-array-add'];
-      for (const subValue of arrayArgs) {
-        arrayArgs.push(toXmlArg(subValue));
+    } catch (e) {
+      if (e instanceof TypeError) {
+        log.warn(e.message);
+      } else {
+        throw e;
       }
-      resultArgs.push(arrayArgs);
-    } else {
-      resultArgs.push([key, toXmlArg(value)]);
     }
   }
   return resultArgs;
@@ -96,9 +106,9 @@ class NSUserDefaults {
 
   /**
    * Reads the content of the given plist file using plutil command line tool
-   * and serializes it to a string
+   * and serializes it to a DOM XML representation
    *
-   * @returns {string} The serialized plist content
+   * @returns {HTMLElement} The serialized plist content
    * @throws {Error} If there was an error during serialization
    */
   async readToXml () {
@@ -108,7 +118,7 @@ class NSUserDefaults {
     } catch (e) {
       throw new Error(`'${this.plist}' cannot be converted to XML. Original error: ${e.stderr || e.message}`);
     }
-    return new DOMParser().parseFromString(stdout);
+    return new DOMParser().parseFromString(stdout, 'text/xml').documentElement;
   }
 
   /**
@@ -117,8 +127,8 @@ class NSUserDefaults {
    *
    * @param {Object} valuesMap Mapping of values to update.
    * If the value is of dictionary type then only the first level dictionary gets
-   * updated. Everything below this level will be overridden. This is known `defaults`
-   * tool limitation.
+   * updated. Everything below this level will be replaced. This is the known limitation
+   * if the `defaults` command line tool.
    * @throws {Error} If there was an error while updating the plist
    */
   async update (valuesMap) {

--- a/lib/defaults-utils.js
+++ b/lib/defaults-utils.js
@@ -116,7 +116,7 @@ class NSUserDefaults {
       const {stdout} = await exec('plutil', ['-convert', 'json', '-o', '-', this.plist]);
       return JSON.parse(stdout);
     } catch (e) {
-      throw new Error(`'${this.plist}' cannot be converted to XML. Original error: ${e.stderr || e.message}`);
+      throw new Error(`'${this.plist}' cannot be converted to JSON. Original error: ${e.stderr || e.message}`);
     }
   }
 
@@ -138,7 +138,7 @@ class NSUserDefaults {
       return;
     }
 
-    const commandArgs = generateUpdateCommandArgs();
+    const commandArgs = generateUpdateCommandArgs(valuesMap);
     try {
       await B.all(commandArgs.map((args) => exec('defaults', ['write', this.plist, ...args])));
     } catch (e) {

--- a/lib/defaults-utils.js
+++ b/lib/defaults-utils.js
@@ -106,19 +106,18 @@ class NSUserDefaults {
 
   /**
    * Reads the content of the given plist file using plutil command line tool
-   * and serializes it to a DOM XML representation
+   * and serializes it to a JSON representation
    *
-   * @returns {HTMLElement} The serialized plist content
+   * @returns {Object} The serialized plist content
    * @throws {Error} If there was an error during serialization
    */
-  async readToXml () {
-    let stdout;
+  async asJson () {
     try {
-      ({stdout} = await exec('plutil', ['-convert', 'xml1', '-o', '-', this.plist]));
+      const {stdout} = await exec('plutil', ['-convert', 'json', '-o', '-', this.plist]);
+      return JSON.parse(stdout);
     } catch (e) {
       throw new Error(`'${this.plist}' cannot be converted to XML. Original error: ${e.stderr || e.message}`);
     }
-    return new DOMParser().parseFromString(stdout, 'text/xml').documentElement;
   }
 
   /**

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -640,7 +640,7 @@ class SimulatorXcode6 extends EventEmitter {
     log.debug('Attempting to launch and quit the simulator, to create directory structure');
     log.debug(`Will launch with Safari? ${safari}`);
 
-    await this.run(startupTimeout);
+    await this.run({startupTimeout});
 
     if (safari) {
       await this.openUrl('http://www.appium.io');

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -470,18 +470,8 @@ class SimulatorXcode6 extends EventEmitter {
    * @property {?string} scaleFactor [null] - Defines the window scale value for the UI client window for the current Simulator.
    *   Equals to null by default, which keeps the current scale unchanged.
    *   It should be one of ['1.0', '0.75', '0.5', '0.33', '0.25'].
-   * @property {boolean} connectHardwareKeyboard [false] - Whether to connect the hardware keyboard to the
-   *   Simulator UI client. Defaults to false.
-   * @property {string} pasteboardAutomaticSync ['off'] - Whether to disable pasteboard sync with the
-   *   Simulator UI client or respect the system wide preference. 'on', 'off', or 'system' is available.
-   *   The sync increases launching simulator process time, but it allows system to sync pasteboard
-   *   with simulators. Follows system-wide preference if the value is 'system'.
-   *   Defaults to 'off'.
    * @property {number} startupTimeout [60000] - Number of milliseconds to wait until Simulator booting
    *   process is completed. The default timeout will be used if not set explicitly.
-   * @property {?boolean} tracePointer [false] - Whether to highlight touches on Simulator
-   *   screen. This is helpful while debugging automated tests or while observing the automation
-   *   recordings.
    */
 
   /**
@@ -492,9 +482,6 @@ class SimulatorXcode6 extends EventEmitter {
     opts = _.cloneDeep(opts);
     _.defaultsDeep(opts, {
       scaleFactor: null,
-      connectHardwareKeyboard: false,
-      pasteboardAutomaticSync: 'off',
-      tracePointer: false,
       startupTimeout: this.startupTimeout,
     });
 
@@ -502,7 +489,6 @@ class SimulatorXcode6 extends EventEmitter {
     const args = [
       '-Fn', simulatorApp,
       '--args', '-CurrentDeviceUDID', this.udid,
-      '-RotateWindowWhenSignaledByGuest', '1',
     ];
 
     if (opts.scaleFactor) {
@@ -510,36 +496,6 @@ class SimulatorXcode6 extends EventEmitter {
       const formattedDeviceName = name.replace(/\s+/g, '-');
       const argumentName = `-SimulatorWindowLastScale-com.apple.CoreSimulator.SimDeviceType.${formattedDeviceName}`;
       args.push(argumentName, opts.scaleFactor);
-    }
-
-    if (_.isBoolean(opts.connectHardwareKeyboard)) {
-      args.push('-ConnectHardwareKeyboard', `${+opts.connectHardwareKeyboard}`);
-    }
-
-    if (opts.tracePointer === true) {
-      args.push(
-        '-ShowSingleTouches', '1',
-        '-ShowPinches', '1',
-        '-ShowPinchPivotPoint', '1',
-        '-HighlightEdgeGestures', '1'
-      );
-    }
-
-    switch (_.lowerCase(opts.pasteboardAutomaticSync)) {
-      case 'on':
-        args.push('-PasteboardAutomaticSync', '1');
-        break;
-      case 'off':
-        // Improve launching simulator performance
-        // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
-        args.push('-PasteboardAutomaticSync', '0');
-        break;
-      case 'system':
-        // Do not add -PasteboardAutomaticSync
-        break;
-      default:
-        log.warn(`['on', 'off' or 'system'] are available as the pasteboard automatic sync option. Defaulting to 'off'.`);
-        args.push('-PasteboardAutomaticSync', '0');
     }
 
     log.info(`Starting Simulator UI with command: open ${args.join(' ')}`);

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -242,25 +242,42 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     }
     this.verifyDevicePreferences(devicePrefs);
     const plistPath = path.resolve(homeFolderPath, 'Library', 'Preferences', 'com.apple.iphonesimulator.plist');
-    if (!await fs.hasAccess(plistPath)) {
-      log.warn(`Simulator preferences file '${plistPath}' is not accessible. ` +
-        `Ignoring Simulator preferences update.`);
-      return false;
-    }
     let newPrefs = {};
     if (!_.isEmpty(devicePrefs)) {
       newPrefs.DevicePreferences = {[this.udid.toUpperCase()]: devicePrefs};
     }
     newPrefs = _.merge(newPrefs, commonPrefs);
     return await preferencesPlistGuard.acquire(SimulatorXcode9.name, async () => {
+      const currentPlistContent = {};
+      if (await fs.exists(plistPath)) {
+        Object.assign(currentPlistContent, await plist.parsePlistFile(plistPath));
+      }
+
       try {
-        const currentPlistContent = await plist.parsePlistFile(plistPath);
-        await plist.updatePlistFile(plistPath, _.merge(currentPlistContent, newPrefs), true);
+        for (const [key, value] of _.toPairs(newPrefs)) {
+          if (_.isPlainObject(value)) {
+
+          } else if (_.isBoolean(value)) {
+
+          } else if (_.isInteger(value)) {
+
+          } else if (_.isNumber(value)) {
+
+          } else if (_.isString(value)) {
+
+          } else {
+            log.debug(`The value ${JSON.stringify(value)} of '${key}' has been skipped, ` +
+              `because it is not known how to handle its type`);
+            continue;
+          }
+
+        }
+        // await plist.updatePlistFile(plistPath, _.merge(currentPlistContent, newPrefs), true);
         log.debug(`Updated ${this.udid} Simulator preferences at '${plistPath}' with ${JSON.stringify(newPrefs)}`);
         return true;
       } catch (e) {
         log.warn(`Cannot update ${this.udid} Simulator preferences at '${plistPath}'. ` +
-                 `Try to delete the file manually in order to reset it. Original error: ${e.message}`);
+          `Try to delete the file manually in order to reset it. Original error: ${e.message}`);
         return false;
       }
     });

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -109,7 +109,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
         // Do not add -PasteboardAutomaticSync
         break;
       default:
-        log.info(`['on', 'off' or 'system'] are available as the pasteboard automatic sync option. Defaulting to 'off'.`);
+        log.info(`['on', 'off' or 'system'] are available as the pasteboard automatic sync option. Defaulting to 'off'`);
         commonPreferences.PasteboardAutomaticSync = false;
     }
     await this.updatePreferences(opts.devicePreferences, commonPreferences);
@@ -124,7 +124,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
           return false;
         }
         if (await this.killUIClient({pid: uiClientPid})) {
-          log.info(`Detected the Simulator UI client was running and killed it. Verifying the current Simulator state...`);
+          log.info(`Detected the Simulator UI client was running and killed it. Verifying the current Simulator state`);
         }
         try {
           // Stopping the UI client kills all running servers for some early XCode versions. This is a known bug
@@ -138,7 +138,8 @@ class SimulatorXcode9 extends SimulatorXcode8 {
           }
           return false;
         }
-        log.info(`Booting Simulator with UDID '${this.udid}' in headless mode. All UI-related capabilities are going to be ignored`);
+        log.info(`Booting Simulator with UDID '${this.udid}' in headless mode. ` +
+          `All UI-related capabilities are going to be ignored`);
         await this.boot();
       } else {
         if (isServerRunning && uiClientPid) {

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -1,11 +1,12 @@
 import SimulatorXcode8 from './simulator-xcode-8';
 import _ from 'lodash';
 import path from 'path';
-import { fs, plist, timing } from 'appium-support';
+import { fs, timing } from 'appium-support';
 import AsyncLock from 'async-lock';
 import log from './logger';
 import { waitForCondition, retryInterval } from 'asyncbox';
 import { toBiometricDomainComponent, getDeveloperRoot } from './utils.js';
+import { NSUserDefaults } from './defaults-utils';
 
 const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
 const startupLock = new AsyncLock();
@@ -53,6 +54,11 @@ class SimulatorXcode9 extends SimulatorXcode8 {
    * @property {?boolean} tracePointer [false] - Whether to highlight touches on Simulator
    * screen. This is helpful while debugging automated tests or while observing the automation
    * recordings.
+   * @property {string} pasteboardAutomaticSync ['off'] - Whether to disable pasteboard sync with the
+   * Simulator UI client or respect the system wide preference. 'on', 'off', or 'system' is available.
+   * The sync increases launching simulator process time, but it allows system to sync pasteboard
+   * with simulators. Follows system-wide preference if the value is 'system'.
+   * Defaults to 'off'.
    * @property {DevicePreferences} devicePreferences: preferences of the newly created Simulator
    * device
    */
@@ -71,6 +77,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       isHeadless: false,
       startupTimeout: this.startupTimeout,
     });
+
     if (opts.scaleFactor) {
       opts.devicePreferences.SimulatorWindowLastScale = parseFloat(opts.scaleFactor);
     }
@@ -79,13 +86,34 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     const commonPreferences = {
       RotateWindowWhenSignaledByGuest: true
     };
-    if (_.isBoolean(opts.connectHardwareKeyboard)) {
-      opts.devicePreferences.ConnectHardwareKeyboard = opts.connectHardwareKeyboard;
-      commonPreferences.ConnectHardwareKeyboard = opts.connectHardwareKeyboard;
+    if (_.isBoolean(opts.connectHardwareKeyboard) || _.isNil(opts.connectHardwareKeyboard)) {
+      opts.devicePreferences.ConnectHardwareKeyboard = opts.connectHardwareKeyboard ?? false;
+      commonPreferences.ConnectHardwareKeyboard = opts.connectHardwareKeyboard ?? false;
     }
-    if (!_.isEmpty(opts.devicePreferences) || !_.isEmpty(commonPreferences)) {
-      await this.updatePreferences(opts.devicePreferences, commonPreferences);
+    if (_.isBoolean(opts.tracePointer)) {
+      commonPreferences.ShowSingleTouches = opts.tracePointer;
+      commonPreferences.ShowPinches = opts.tracePointer;
+      commonPreferences.ShowPinchPivotPoint = opts.tracePointer;
+      commonPreferences.HighlightEdgeGestures = opts.tracePointer;
     }
+    switch (_.lowerCase(opts.pasteboardAutomaticSync)) {
+      case 'on':
+        commonPreferences.PasteboardAutomaticSync = true;
+        break;
+      case 'off':
+        // Improve launching simulator performance
+        // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
+        commonPreferences.PasteboardAutomaticSync = false;
+        break;
+      case 'system':
+        // Do not add -PasteboardAutomaticSync
+        break;
+      default:
+        log.info(`['on', 'off' or 'system'] are available as the pasteboard automatic sync option. Defaulting to 'off'.`);
+        commonPreferences.PasteboardAutomaticSync = false;
+    }
+    await this.updatePreferences(opts.devicePreferences, commonPreferences);
+
     const timer = new timing.Timer().start();
     const shouldWaitForBoot = await startupLock.acquire(this.uiClientBundleId, async () => {
       const isServerRunning = await this.isRunning();
@@ -242,38 +270,29 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     }
     this.verifyDevicePreferences(devicePrefs);
     const plistPath = path.resolve(homeFolderPath, 'Library', 'Preferences', 'com.apple.iphonesimulator.plist');
-    let newPrefs = {};
-    if (!_.isEmpty(devicePrefs)) {
-      newPrefs.DevicePreferences = {[this.udid.toUpperCase()]: devicePrefs};
-    }
-    newPrefs = _.merge(newPrefs, commonPrefs);
     return await preferencesPlistGuard.acquire(SimulatorXcode9.name, async () => {
-      const currentPlistContent = {};
-      if (await fs.exists(plistPath)) {
-        Object.assign(currentPlistContent, await plist.parsePlistFile(plistPath));
-      }
-
+      const defaults = new NSUserDefaults(plistPath);
+      const prefsToUpdate = _.clone(commonPrefs);
       try {
-        for (const [key, value] of _.toPairs(newPrefs)) {
-          if (_.isPlainObject(value)) {
-
-          } else if (_.isBoolean(value)) {
-
-          } else if (_.isInteger(value)) {
-
-          } else if (_.isNumber(value)) {
-
-          } else if (_.isString(value)) {
-
-          } else {
-            log.debug(`The value ${JSON.stringify(value)} of '${key}' has been skipped, ` +
-              `because it is not known how to handle its type`);
-            continue;
+        if (!_.isEmpty(devicePrefs)) {
+          let existingDevicePrefs;
+          const udidKey = this.udid.toUpperCase();
+          if (await fs.exists(plistPath)) {
+            const currentPlistContent = await defaults.asJson();
+            if (_.isPlainObject(currentPlistContent.DevicePreferences)
+                && _.isPlainObject(currentPlistContent.DevicePreferences[udidKey])) {
+              existingDevicePrefs = currentPlistContent.DevicePreferences[udidKey];
+            }
           }
-
+          Object.assign(prefsToUpdate, {
+            DevicePreferences: {
+              [udidKey]: Object.assign({}, existingDevicePrefs || {}, devicePrefs)
+            }
+          });
         }
-        // await plist.updatePlistFile(plistPath, _.merge(currentPlistContent, newPrefs), true);
-        log.debug(`Updated ${this.udid} Simulator preferences at '${plistPath}' with ${JSON.stringify(newPrefs)}`);
+        await defaults.update(prefsToUpdate);
+        log.debug(`Updated ${this.udid} Simulator preferences at '${plistPath}' with ` +
+          JSON.stringify(prefsToUpdate));
         return true;
       } catch (e) {
         log.warn(`Cannot update ${this.udid} Simulator preferences at '${plistPath}'. ` +

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -327,35 +327,6 @@ async function activateApp (pid) {
   }
 }
 
-/**
- * Writes the given key-value pair to macOS plist using the `defaults`
- * command line utility. Read https://eclecticlight.co/2017/07/06/sticky-preferences-why-trashing-or-editing-them-may-not-change-anything/
- * for more details on wht this is needed.
- *
- * @param {string} plist Full path to the destination plist file
- * @param {string} name The name of the value to be written
- * @param {*} value The value to write
- * @throws {TypeError} If there was a failure while writing the value to defaults registry
- */
-async function writeDefaults (plist, name, value) {
-  const cmd = ['defaults', 'write', plist];
-  if (_.isPlainObject(value)) {
-
-  } else if (_.isBoolean(value)) {
-    cmd.push('-bool', value ? 'YES' : 'NO');
-  } else if (_.isInteger(value)) {
-    cmd.push('-int', value);
-  } else if (_.isNumber(value)) {
-    cmd.push('-float', value);
-  } else if (_.isString(value)) {
-    cmd.push('-string', value);
-  } else {
-    throw TypeError(`The value ${JSON.stringify(value)} of '${name}' cannot be written, ` +
-      `because it is not known how to handle its type`);
-  }
-  await exec(cmd);
-}
-
 export {
   killAllSimulators,
   endAllSimulatorDaemons,
@@ -369,7 +340,6 @@ export {
   toBiometricDomainComponent,
   getDeveloperRoot,
   activateApp,
-  writeDefaults,
   SAFARI_STARTUP_TIMEOUT,
   MOBILE_SAFARI_BUNDLE_ID,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -327,6 +327,35 @@ async function activateApp (pid) {
   }
 }
 
+/**
+ * Writes the given key-value pair to macOS plist using the `defaults`
+ * command line utility. Read https://eclecticlight.co/2017/07/06/sticky-preferences-why-trashing-or-editing-them-may-not-change-anything/
+ * for more details on wht this is needed.
+ *
+ * @param {string} plist Full path to the destination plist file
+ * @param {string} name The name of the value to be written
+ * @param {*} value The value to write
+ * @throws {TypeError} If there was a failure while writing the value to defaults registry
+ */
+async function writeDefaults (plist, name, value) {
+  const cmd = ['defaults', 'write', plist];
+  if (_.isPlainObject(value)) {
+
+  } else if (_.isBoolean(value)) {
+    cmd.push('-bool', value ? 'YES' : 'NO');
+  } else if (_.isInteger(value)) {
+    cmd.push('-int', value);
+  } else if (_.isNumber(value)) {
+    cmd.push('-float', value);
+  } else if (_.isString(value)) {
+    cmd.push('-string', value);
+  } else {
+    throw TypeError(`The value ${JSON.stringify(value)} of '${name}' cannot be written, ` +
+      `because it is not known how to handle its type`);
+  }
+  await exec(cmd);
+}
+
 export {
   killAllSimulators,
   endAllSimulatorDaemons,
@@ -340,6 +369,7 @@ export {
   toBiometricDomainComponent,
   getDeveloperRoot,
   activateApp,
+  writeDefaults,
   SAFARI_STARTUP_TIMEOUT,
   MOBILE_SAFARI_BUNDLE_ID,
 };

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "node-simctl": "^6.4.0",
     "semver": "^7.0.0",
     "source-map-support": "^0.5.3",
-    "teen_process": "^1.3.0"
+    "teen_process": "^1.3.0",
+    "xmldom": "^0.4.0"
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",

--- a/test/unit/defaults-utils-specs.js
+++ b/test/unit/defaults-utils-specs.js
@@ -1,9 +1,7 @@
 import { toXmlArg, generateUpdateCommandArgs } from '../../lib/defaults-utils';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import chai, { expect } from 'chai';
 
 chai.should();
-chai.use(chaiAsPromised);
 
 describe('defaults-utils', function () {
 
@@ -28,6 +26,10 @@ describe('defaults-utils', function () {
     it('could properly convert dict value types to a XML representation', function () {
       toXmlArg({k1: true, k2: {k3: 1.1, k4: []}}).should.eql(
         '<dict><key>k1</key><true/><key>k2</key><dict><key>k3</key><real>1.1</real><key>k4</key><array/></dict></dict>');
+    });
+
+    it('fails to convert an unknown value type', function () {
+      expect(() => toXmlArg(null)).to.throw;
     });
 
   });

--- a/test/unit/defaults-utils-specs.js
+++ b/test/unit/defaults-utils-specs.js
@@ -1,0 +1,67 @@
+import { toXmlArg, generateUpdateCommandArgs } from '../../lib/defaults-utils';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('defaults-utils', function () {
+
+  describe('toXmlArg', function () {
+
+    it('could properly convert simple value types to a XML representation', function () {
+      for (const [actual, expected] of [
+        [1, '<integer>1</integer>'],
+        [1.1, '<real>1.1</real>'],
+        ['1', '<string>1</string>'],
+        [true, '<true/>'],
+        [false, '<false/>'],
+      ]) {
+        toXmlArg(actual).should.eql(expected);
+      }
+    });
+
+    it('could properly convert array value types to a XML representation', function () {
+      toXmlArg([1.1, false]).should.eql('<array><real>1.1</real><false/></array>');
+    });
+
+    it('could properly convert dict value types to a XML representation', function () {
+      toXmlArg({k1: true, k2: {k3: 1.1, k4: []}}).should.eql(
+        '<dict><key>k1</key><true/><key>k2</key><dict><key>k3</key><real>1.1</real><key>k4</key><array/></dict></dict>');
+    });
+
+  });
+
+  describe('generateUpdateCommandArgs', function () {
+
+    it('could properly generate command args for simple value types', function () {
+      generateUpdateCommandArgs({
+        k1: 1,
+        k2: 1.1,
+        k3: '1',
+        k4: true,
+        k5: false,
+      }).should.eql([
+        ['k1', '<integer>1</integer>'],
+        ['k2', '<real>1.1</real>'],
+        ['k3', '<string>1</string>'],
+        ['k4', '<true/>'],
+        ['k5', '<false/>'],
+      ]);
+    });
+
+    it('could properly generate command args for dict value types', function () {
+      generateUpdateCommandArgs({
+        k1: {
+          k2: {
+            k3: 1,
+          },
+        }
+      }).should.eql([
+        ['k1', '-dict-add', 'k2', '<dict><key>k3</key><integer>1</integer></dict>'],
+      ]);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Plist preference files on macOS are managed by cfprefsd. Changing the file itself without letting the daemon know about it has no effect. Read https://eclecticlight.co/2017/07/06/sticky-preferences-why-trashing-or-editing-them-may-not-change-anything/ and https://shadowfile.inode.link/blog/2018/06/advanced-defaults1-usage/ for more details