### PR TITLE
fix: idb and AppleScript Geo Location setters

### DIFF
--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -53,8 +53,7 @@ async function setLocationWithIdb (idb, latitude, longitude) {
     } catch (e) {
       throw new Error(`Failed to set geolocation with idb. Original error: ${e.stderr || e.message}`);
     }
-  }
-  else {
+  } else {
     throw new Error('Failed to set geolocation with idb because it is not installed or the "launchWithIDB" capability was not set');
   }
 }
@@ -73,12 +72,14 @@ async function setLocationWithIdb (idb, latitude, longitude) {
  */
 async function setLocationWithAppleScript (sim, latitude, longitude, menu = 'Debug') {
   // Make sure system-wide decimal separator is used
-  const decimalSeparator = (await sim.executeUIClientScript(`
-    use framework "Foundation"
-    return (decimalSeparator of init() of alloc() of NSNumberFormatter of current application as string)
-  `)).trim();
+  const decimalSeparator = (await exec('/usr/bin/python', [
+    '-c',
+    'from AppKit import NSNumberFormatter;' +
+    'import sys;' +
+    'sys.stdout.write(NSNumberFormatter.alloc().init().decimalSeparator())'
+  ])).stdout;
 
-  const [latitudeStr, longitudeStr] = [latitude, longitude].map(s => s.replace(/\D/g, decimalSeparator))
+  const [latitudeStr, longitudeStr] = [latitude, longitude].map((coord) => `${coord}`.replace(/\D/g, decimalSeparator));
 
   const output = await sim.executeUIClientScript(`
     tell application "System Events"

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -54,7 +54,9 @@ async function setLocationWithIdb (idb, latitude, longitude) {
       throw new Error(`Failed to set geolocation with idb. Original error: ${e.stderr || e.message}`);
     }
   }
-  throw new Error('Failed to set geolocation with idb because it is not installed');
+  else {
+    throw new Error('Failed to set geolocation with idb because it is not installed');
+  }
 }
 
 
@@ -70,10 +72,14 @@ async function setLocationWithIdb (idb, latitude, longitude) {
  * @throws {Error} If it failed to set the location
  */
 async function setLocationWithAppleScript (sim, latitude, longitude, menu = 'Debug') {
-  const decimalSeparator = (0.1).toLocaleString().replace(/\d/g, '');
   // Make sure system-wide decimal separator is used
-  const latitudeStr = `${latitude}`.replace(/\D/g, decimalSeparator);
-  const longitudeStr = `${longitude}`.replace(/\D/g, decimalSeparator);
+  const decimalSeparator = (await sim.executeUIClientScript(`
+    use framework "Foundation"
+    return (decimalSeparator of init() of alloc() of NSNumberFormatter of current application as string)
+  `)).trim();
+
+  const [latitudeStr, longitudeStr] = [latitude, longitude].map(s => s.replace(/\D/g, decimalSeparator))
+
   const output = await sim.executeUIClientScript(`
     tell application "System Events"
       tell process "Simulator"

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -55,7 +55,7 @@ async function setLocationWithIdb (idb, latitude, longitude) {
     }
   }
   else {
-    throw new Error('Failed to set geolocation with idb because it is not installed');
+    throw new Error('Failed to set geolocation with idb because it is not installed or the "launchWithIDB" capability was not set');
   }
 }
 

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -47,14 +47,14 @@ async function setLocationWithLyft (udid, latitude, longitude) {
  * @throws {Error} If it failed to set the location
  */
 async function setLocationWithIdb (idb, latitude, longitude) {
-  if (idb) {
-    try {
-      await idb.setLocation(latitude, longitude);
-    } catch (e) {
-      throw new Error(`Failed to set geolocation with idb. Original error: ${e.stderr || e.message}`);
-    }
-  } else {
+  if (!idb) {
     throw new Error('Failed to set geolocation with idb because it is not installed or the "launchWithIDB" capability was not set');
+  }
+
+  try {
+    await idb.setLocation(latitude, longitude);
+  } catch (e) {
+    throw new Error(`Failed to set geolocation with idb. Original error: ${e.stderr || e.message}`);
   }
 }
 


### PR DESCRIPTION
This fixes two issues with `setGeoLocation`:
1. The `idb` location setter is throwing an error even on success, making the fallback `AppleScript` location setter always run
1. The `AppleScript` location setter fails to set valid coordinates for certain locales due to a wrong calculation of the decimal separator

   To test:
   1. On macOS go to `Language and Region` → `System Preferences` and either change your locale settings or change the separator by going to `Advanced` → `Number separators` → `Decimal`
   
      <img width="40%" alt="walkthrough 1" src="https://user-images.githubusercontent.com/3788982/113600016-b5ac3500-963f-11eb-876d-c90d53ed608e.png"> <img width="40%" alt="walkthrough 2" src="https://user-images.githubusercontent.com/3788982/113600021-b6dd6200-963f-11eb-87aa-8d2e0965b984.png">
   1. Run the script to see your changes reflected:
      ```shell
      osascript -e 'use framework "Foundation"' -e 'return (decimalSeparator of init() of alloc() of NSNumberFormatter of current application as string)'
      ```
   1. Open Simulator,  enter Custom Location /w the new separator: `Feature` → `Location` → `Custom Location`
