### PR TITLE
feat: Add a possibility to change locale settings without restarting the Simulator

### DIFF
--- a/lib/defaults-utils.js
+++ b/lib/defaults-utils.js
@@ -74,15 +74,15 @@ function generateDefaultsCommandArgs (valuesMap, replace = false) {
   const resultArgs = [];
   for (const [key, value] of _.toPairs(valuesMap)) {
     try {
-      if (_.isPlainObject(value)) {
-        const dictArgs = [key, replace ? '-dict' : '-dict-add'];
+      if (!replace && _.isPlainObject(value)) {
+        const dictArgs = [key, '-dict-add'];
         for (const [subKey, subValue] of _.toPairs(value)) {
           dictArgs.push(subKey, toXmlArg(subValue));
         }
         resultArgs.push(dictArgs);
-      } else if (_.isArray(value)) {
-        const arrayArgs = [key, replace ? '-array' : '-array-add'];
-        for (const subValue of arrayArgs) {
+      } else if (!replace && _.isArray(value)) {
+        const arrayArgs = [key, '-array-add'];
+        for (const subValue of value) {
           arrayArgs.push(toXmlArg(subValue));
         }
         resultArgs.push(arrayArgs);

--- a/lib/defaults-utils.js
+++ b/lib/defaults-utils.js
@@ -64,21 +64,24 @@ function toXmlArg (value, serialize = true) {
  * for more details.
  *
  * @param {Object} valuesMap Preferences mapping
+ * @param {Boolean} replace [false] Whether to generate arguments that replace
+ * complex typed values like arrays or dictionaries in the current plist or
+ * update them (the default settings)
  * @returns {Array<Array<string>>} Each item in the array
  * is the `defaults write <plist>` command suffix
  */
-function generateUpdateCommandArgs (valuesMap) {
+function generateDefaultsCommandArgs (valuesMap, replace = false) {
   const resultArgs = [];
   for (const [key, value] of _.toPairs(valuesMap)) {
     try {
       if (_.isPlainObject(value)) {
-        const dictArgs = [key, '-dict-add'];
+        const dictArgs = [key, replace ? '-dict' : '-dict-add'];
         for (const [subKey, subValue] of _.toPairs(value)) {
           dictArgs.push(subKey, toXmlArg(subValue));
         }
         resultArgs.push(dictArgs);
       } else if (_.isArray(value)) {
-        const arrayArgs = [key, '-array-add'];
+        const arrayArgs = [key, replace ? '-array' : '-array-add'];
         for (const subValue of arrayArgs) {
           arrayArgs.push(toXmlArg(subValue));
         }
@@ -138,7 +141,7 @@ class NSUserDefaults {
       return;
     }
 
-    const commandArgs = generateUpdateCommandArgs(valuesMap);
+    const commandArgs = generateDefaultsCommandArgs(valuesMap);
     try {
       await B.all(commandArgs.map((args) => exec('defaults', ['write', this.plist, ...args])));
     } catch (e) {
@@ -150,5 +153,5 @@ class NSUserDefaults {
 
 export {
   NSUserDefaults,
-  toXmlArg, generateUpdateCommandArgs,
+  toXmlArg, generateDefaultsCommandArgs,
 };

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -6,7 +6,8 @@ import AsyncLock from 'async-lock';
 import log from './logger';
 import { waitForCondition, retryInterval } from 'asyncbox';
 import { toBiometricDomainComponent, getDeveloperRoot } from './utils.js';
-import { NSUserDefaults } from './defaults-utils';
+import { NSUserDefaults, generateDefaultsCommandArgs } from './defaults-utils';
+import B from 'bluebird';
 
 const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
 const startupLock = new AsyncLock();
@@ -412,6 +413,101 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     const devRoot = await getDeveloperRoot();
     return path.resolve(devRoot,
       'Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/LaunchDaemons');
+  }
+
+  /**
+   * @typedef {Object} KeyboardOptions
+   * @property {!string} name The name of the keyboard locale, for example `en_US` or `de_CH`
+   * @property {!string} layout The keyboard layout, for example `QUERTY` or `Ukrainian`
+   * @property {?string} hardware Could either be `Automatic` or `null`
+   */
+
+  /**
+   * @typedef {Object} LanguageOptions
+   * @property {!string} name The name of the language, for example `de` or `zh-Hant-CN`
+   */
+
+  /**
+   * @typedef {Object} LocaleOptions
+   * @property {!string} name The name of the system locale, for example `de_CH` or `zh_CN`
+   * @property {?string} calendar Optional calendar format, for example `gregorian` or `persian`
+   */
+
+  /**
+   * @typedef {Object} LocalizationOptions
+   * @property {?KeyboardOptions} keyboard
+   * @property {?LanguageOptions} language
+   * @property {?LocaleOptions} locale
+   */
+
+  /**
+   * Change localization settings on the currently booted simulator
+   *
+   * @param {?LocalizationOptions} opts
+   * @throws {Error} If there was a failure while setting the preferences
+   * @returns {boolean} `true` if any of settings has been successfully changed
+   */
+  async configureLocalization (opts = {}) {
+    if (_.isEmpty(opts)) {
+      return false;
+    }
+
+    const { language, locale, keyboard } = opts;
+    const globalPrefs = {};
+    let keyboardId = null;
+    if (_.isPlainObject(keyboard)) {
+      const { name, layout, hardware } = keyboard;
+      if (!name) {
+        throw new Error(`The 'keyboard' field must have a valid name set`);
+      }
+      if (!layout) {
+        throw new Error(`The 'keyboard' field must have a valid layout set`);
+      }
+      keyboardId = `${name}@sw=${layout}`;
+      if (hardware) {
+        keyboardId += `;@hw=${hardware}`;
+      }
+      globalPrefs.AppleKeyboards = [keyboardId];
+    }
+    if (_.isPlainObject(language)) {
+      const { name } = language;
+      if (!name) {
+        throw new Error(`The 'language' field must have a valid name set`);
+      }
+      globalPrefs.AppleLanguages = [name];
+    }
+    if (_.isPlainObject(locale)) {
+      const { name, calendar } = locale;
+      if (!name) {
+        throw new Error(`The 'locale' field must have a valid name set`);
+      }
+      let localeId = name;
+      if (calendar) {
+        localeId += `@calendar=${calendar}`;
+      }
+      globalPrefs.AppleLocale = localeId;
+    }
+    if (_.isEmpty(globalPrefs)) {
+      return false;
+    }
+
+    const argChunks = generateDefaultsCommandArgs(globalPrefs, true);
+    await B.all(argChunks.map((args) => this.simctl.spawnProcess([
+      'defaults', 'write', '.GlobalPreferences.plist', ...args
+    ])));
+
+    if (keyboardId) {
+      const argChunks = generateDefaultsCommandArgs({
+        KeyboardsCurrentAndNext: [keyboardId],
+        KeyboardLastUsed: keyboardId,
+        KeyboardLastUsedForLanguage: { [keyboard.name]: keyboardId }
+      }, true);
+      await B.all(argChunks.map((args) => this.simctl.spawnProcess([
+        'defaults', 'write', 'com.apple.Preferences', ...args
+      ])));
+    }
+
+    return true;
   }
 
 }

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -370,6 +370,28 @@ describe('advanced features', function () {
     });
   });
 
+  describe('configureLocalization', function () {
+    it(`should properly set locale settings`, async function () {
+      if (!_.isFunction(sim.configureLocalization)) {
+        return this.skip();
+      }
+
+      await sim.configureLocalization({
+        language: {
+          name: 'en'
+        },
+        locale: {
+          name: 'en_US',
+          calendar: 'gregorian',
+        },
+        keyboard: {
+          name: 'en_US',
+          layout: 'QWERTY',
+        }
+      });
+    });
+  });
+
   describe('keychains', function () {
     this.retries(2);
 

--- a/test/unit/defaults-utils-specs.js
+++ b/test/unit/defaults-utils-specs.js
@@ -1,4 +1,4 @@
-import { toXmlArg, generateUpdateCommandArgs } from '../../lib/defaults-utils';
+import { toXmlArg, generateDefaultsCommandArgs } from '../../lib/defaults-utils';
 import chai, { expect } from 'chai';
 
 chai.should();
@@ -34,10 +34,10 @@ describe('defaults-utils', function () {
 
   });
 
-  describe('generateUpdateCommandArgs', function () {
+  describe('generateDefaultsCommandArgs', function () {
 
     it('could properly generate command args for simple value types', function () {
-      generateUpdateCommandArgs({
+      generateDefaultsCommandArgs({
         k1: 1,
         k2: 1.1,
         k3: '1',
@@ -53,7 +53,7 @@ describe('defaults-utils', function () {
     });
 
     it('could properly generate command args for dict value types', function () {
-      generateUpdateCommandArgs({
+      generateDefaultsCommandArgs({
         k1: {
           k2: {
             k3: 1,

--- a/test/unit/defaults-utils-specs.js
+++ b/test/unit/defaults-utils-specs.js
@@ -64,6 +64,18 @@ describe('defaults-utils', function () {
       ]);
     });
 
+    it('could properly generate command args for value types with replacement', function () {
+      generateDefaultsCommandArgs({
+        AppleLanguages: ['en'],
+        AppleLocale: 'en_US@calendar=gregorian',
+        AppleKeyboards: ['en_US@sw=QWERTY']
+      }, true).should.eql([
+        ['AppleLanguages', '<array><string>en</string></array>'],
+        ['AppleLocale', '<string>en_US@calendar=gregorian</string>'],
+        ['AppleKeyboards', '<array><string>en_US@sw=QWERTY</string></array>'],
+      ]);
+    });
+
   });
 
 });


### PR DESCRIPTION
The idea is similar to https://github.com/appium/appium-ios-simulator/pull/298 except of Simulator has its own `defaults` tool, which could be triggered via `simctl spawn`