### PR TITLE
feat: add node-scimtl with ability to define xcrun path in env

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "asyncbox": "^2.3.1",
     "bluebird": "^3.5.1",
     "lodash": "^4.2.1",
-    "node-simctl": "^6.4.0",
+    "node-simctl": "^6.5.0",
     "semver": "^7.0.0",
     "source-map-support": "^0.5.3",
     "teen_process": "^1.3.0",


### PR DESCRIPTION
I need to have a feature from https://github.com/appium/node-simctl/pull/147 in appium.
So I'm going to update node-simctl in appium-ios-simulator and then - appium-ios-simulator in appium.
@KazuCocoa @jlipps 