### PR TITLE
feat: add DidShowContinuousPathIntroduction 1 for iOS 15

### DIFF
--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -116,6 +116,15 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     }
     await this.updatePreferences(opts.devicePreferences, commonPreferences);
 
+    // To disable 'DidShowContinuousPathIntroduction' for iOS 15+ simulators since changing the preference via WDA
+    // does not work on them.
+    const argChunks = generateDefaultsCommandArgs({
+      DidShowContinuousPathIntroduction: 1
+    }, true);
+    await B.all(argChunks.map((args) => this.simctl.spawnProcess([
+      'defaults', 'write', 'com.apple.keyboard.preferences', ...args
+    ])));
+
     const timer = new timing.Timer().start();
     const shouldWaitForBoot = await startupLock.acquire(this.uiClientBundleId, async () => {
       const isServerRunning = await this.isRunning();

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -170,9 +170,9 @@ class SimulatorXcode9 extends SimulatorXcode8 {
    * Configure keyboard preference as 'com.apple.keyboard.preferences' domain via 'defaults' command.
    */
   async configureKeyboardPreference () {
-    // To disable 'DidShowContinuousPathIntroduction' for iOS 15+ simulators since changing the preference via WDA
-    // does not work on them.
     const argChunks = generateDefaultsCommandArgs({
+    // To disable 'DidShowContinuousPathIntroduction' for iOS 15+ simulators since changing the preference via WDA
+    // does not work on them. Lower than the versions also can have this preference, but nothing happen.
       DidShowContinuousPathIntroduction: 1
     }, true);
     await B.all(argChunks.map((args) => this.simctl.spawnProcess([

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -116,14 +116,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     }
     await this.updatePreferences(opts.devicePreferences, commonPreferences);
 
-    // To disable 'DidShowContinuousPathIntroduction' for iOS 15+ simulators since changing the preference via WDA
-    // does not work on them.
-    const argChunks = generateDefaultsCommandArgs({
-      DidShowContinuousPathIntroduction: 1
-    }, true);
-    await B.all(argChunks.map((args) => this.simctl.spawnProcess([
-      'defaults', 'write', 'com.apple.keyboard.preferences', ...args
-    ])));
+    await this.configureKeyboardPreference();
 
     const timer = new timing.Timer().start();
     const shouldWaitForBoot = await startupLock.acquire(this.uiClientBundleId, async () => {
@@ -171,6 +164,20 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       await this.waitForBoot(opts.startupTimeout);
       log.info(`Simulator with UDID ${this.udid} booted in ${timer.getDuration().asSeconds.toFixed(3)}s`);
     }
+  }
+
+  /**
+   * Configure keyboard preference as 'com.apple.keyboard.preferences' domain via 'defaults' command.
+   */
+  async configureKeyboardPreference () {
+    // To disable 'DidShowContinuousPathIntroduction' for iOS 15+ simulators since changing the preference via WDA
+    // does not work on them.
+    const argChunks = generateDefaultsCommandArgs({
+      DidShowContinuousPathIntroduction: 1
+    }, true);
+    await B.all(argChunks.map((args) => this.simctl.spawnProcess([
+      'defaults', 'write', 'com.apple.keyboard.preferences', ...args
+    ])));
   }
 
   /***

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -14,7 +14,7 @@ const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
 const startupLock = new AsyncLock();
 const preferencesPlistGuard = new AsyncLock();
 const ENROLLMENT_NOTIFICATION_RECEIVER = 'com.apple.BiometricKit.enrollmentChanged';
-const DOMAIN_KEYBOARD_PREFERENCE = 'com.apple.keyboard.preferences';
+const DOMAIN_KEYBOARD_PREFERENCES = 'com.apple.keyboard.preferences';
 
 class SimulatorXcode9 extends SimulatorXcode8 {
   constructor (udid, xcodeVersion) {
@@ -117,8 +117,6 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     }
     await this.updatePreferences(opts.devicePreferences, commonPreferences);
 
-    await this.disableKeyboardIntroduction();
-
     const timer = new timing.Timer().start();
     const shouldWaitForBoot = await startupLock.acquire(this.uiClientBundleId, async () => {
       const isServerRunning = await this.isRunning();
@@ -165,6 +163,8 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       await this.waitForBoot(opts.startupTimeout);
       log.info(`Simulator with UDID ${this.udid} booted in ${timer.getDuration().asSeconds.toFixed(3)}s`);
     }
+
+    await this.disableKeyboardIntroduction();
   }
 
   /**
@@ -177,7 +177,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       DidShowContinuousPathIntroduction: 1
     }, true);
     await B.all(argChunks.map((args) => this.simctl.spawnProcess([
-      'defaults', 'write', DOMAIN_KEYBOARD_PREFERENCE, ...args
+      'defaults', 'write', DOMAIN_KEYBOARD_PREFERENCES, ...args
     ])));
   }
 

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -14,6 +14,7 @@ const SIMULATOR_SHUTDOWN_TIMEOUT = 15 * 1000;
 const startupLock = new AsyncLock();
 const preferencesPlistGuard = new AsyncLock();
 const ENROLLMENT_NOTIFICATION_RECEIVER = 'com.apple.BiometricKit.enrollmentChanged';
+const DOMAIN_KEYBOARD_PREFERENCE = 'com.apple.keyboard.preferences';
 
 class SimulatorXcode9 extends SimulatorXcode8 {
   constructor (udid, xcodeVersion) {
@@ -116,7 +117,7 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     }
     await this.updatePreferences(opts.devicePreferences, commonPreferences);
 
-    await this.configureKeyboardPreference();
+    await this.disableKeyboardIntroduction();
 
     const timer = new timing.Timer().start();
     const shouldWaitForBoot = await startupLock.acquire(this.uiClientBundleId, async () => {
@@ -167,16 +168,16 @@ class SimulatorXcode9 extends SimulatorXcode8 {
   }
 
   /**
-   * Configure keyboard preference as 'com.apple.keyboard.preferences' domain via 'defaults' command.
+   * Disable keyboard tutorial as 'com.apple.keyboard.preferences' domain via 'defaults' command.
    */
-  async configureKeyboardPreference () {
+  async disableKeyboardIntroduction () {
     const argChunks = generateDefaultsCommandArgs({
     // To disable 'DidShowContinuousPathIntroduction' for iOS 15+ simulators since changing the preference via WDA
     // does not work on them. Lower than the versions also can have this preference, but nothing happen.
       DidShowContinuousPathIntroduction: 1
     }, true);
     await B.all(argChunks.map((args) => this.simctl.spawnProcess([
-      'defaults', 'write', 'com.apple.keyboard.preferences', ...args
+      'defaults', 'write', DOMAIN_KEYBOARD_PREFERENCE, ...args
     ])));
   }
 


### PR DESCRIPTION
I figured out how to apply https://github.com/appium/WebDriverAgent/blob/a1824895274c60798b506f31054e4ce1e0400c71/WebDriverAgentLib/Utilities/FBConfiguration.m#L268 for iOS 15 simulators.
We can modify the preference only via its domain. The WDA one is for iOS 14-.

No issues happen by calling this for lower than iOS 15 simulators.

After this change, `com.apple.keyboard.preferences` will hale the below on simulator iOS 15:
```
 % xcrun simctl spawn booted defaults read com.apple.keyboard.preferences
{
    DictationLanguagesEnabled =     {
        "en_US" = 1;
    };
    DidShowContinuousPathIntroduction = 1;
}
```