### PR TITLE
chore: Ignore errors related to keyboard introduction setup

### DIFF
--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -18,6 +18,50 @@ const preferencesPlistGuard = new AsyncLock();
 const ENROLLMENT_NOTIFICATION_RECEIVER = 'com.apple.BiometricKit.enrollmentChanged';
 const DOMAIN_KEYBOARD_PREFERENCES = 'com.apple.keyboard.preferences';
 
+function compileCommonSimulatorPreferences (opts = {}) {
+  const {
+    connectHardwareKeyboard,
+    tracePointer,
+    pasteboardAutomaticSync,
+  } = opts;
+  const commonPreferences = {
+    // This option is necessary to make the Simulator window follow
+    // the actual XCUIDevice orientation
+    RotateWindowWhenSignaledByGuest: true,
+    // https://github.com/appium/appium/issues/16418
+    StartLastDeviceOnLaunch: false,
+    DetachOnWindowClose: false,
+    AttachBootedOnStart: true,
+  };
+  if (_.isBoolean(connectHardwareKeyboard) || _.isNil(connectHardwareKeyboard)) {
+    opts.devicePreferences.ConnectHardwareKeyboard = connectHardwareKeyboard ?? false;
+    commonPreferences.ConnectHardwareKeyboard = connectHardwareKeyboard ?? false;
+  }
+  if (_.isBoolean(tracePointer)) {
+    commonPreferences.ShowSingleTouches = tracePointer;
+    commonPreferences.ShowPinches = tracePointer;
+    commonPreferences.ShowPinchPivotPoint = tracePointer;
+    commonPreferences.HighlightEdgeGestures = tracePointer;
+  }
+  switch (_.lowerCase(pasteboardAutomaticSync)) {
+    case 'on':
+      commonPreferences.PasteboardAutomaticSync = true;
+      break;
+    case 'off':
+      // Improve launching simulator performance
+      // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
+      commonPreferences.PasteboardAutomaticSync = false;
+      break;
+    case 'system':
+      // Do not add -PasteboardAutomaticSync
+      break;
+    default:
+      log.info(`['on', 'off' or 'system'] are available as the pasteboard automatic sync option. Defaulting to 'off'`);
+      commonPreferences.PasteboardAutomaticSync = false;
+  }
+  return commonPreferences;
+}
+
 class SimulatorXcode9 extends SimulatorXcode8 {
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
@@ -86,41 +130,10 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     if (opts.scaleFactor) {
       opts.devicePreferences.SimulatorWindowLastScale = parseFloat(opts.scaleFactor);
     }
-    const commonPreferences = {
-      // This option is necessary to make the Simulator window follow
-      // the actual XCUIDevice orientation
-      RotateWindowWhenSignaledByGuest: true,
-      // https://github.com/appium/appium/issues/16418
-      StartLastDeviceOnLaunch: false,
-      DetachOnWindowClose: false,
-      AttachBootedOnStart: true,
-    };
     if (_.isBoolean(opts.connectHardwareKeyboard) || _.isNil(opts.connectHardwareKeyboard)) {
       opts.devicePreferences.ConnectHardwareKeyboard = opts.connectHardwareKeyboard ?? false;
-      commonPreferences.ConnectHardwareKeyboard = opts.connectHardwareKeyboard ?? false;
     }
-    if (_.isBoolean(opts.tracePointer)) {
-      commonPreferences.ShowSingleTouches = opts.tracePointer;
-      commonPreferences.ShowPinches = opts.tracePointer;
-      commonPreferences.ShowPinchPivotPoint = opts.tracePointer;
-      commonPreferences.HighlightEdgeGestures = opts.tracePointer;
-    }
-    switch (_.lowerCase(opts.pasteboardAutomaticSync)) {
-      case 'on':
-        commonPreferences.PasteboardAutomaticSync = true;
-        break;
-      case 'off':
-        // Improve launching simulator performance
-        // https://github.com/WebKit/webkit/blob/master/Tools/Scripts/webkitpy/xcode/simulated_device.py#L413
-        commonPreferences.PasteboardAutomaticSync = false;
-        break;
-      case 'system':
-        // Do not add -PasteboardAutomaticSync
-        break;
-      default:
-        log.info(`['on', 'off' or 'system'] are available as the pasteboard automatic sync option. Defaulting to 'off'`);
-        commonPreferences.PasteboardAutomaticSync = false;
-    }
+    const commonPreferences = compileCommonSimulatorPreferences(opts);
     await this.updatePreferences(opts.devicePreferences, commonPreferences);
 
     const timer = new timing.Timer().start();
@@ -170,7 +183,13 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       log.info(`Simulator with UDID ${this.udid} booted in ${timer.getDuration().asSeconds.toFixed(3)}s`);
     }
 
-    await this.disableKeyboardIntroduction();
+    (async () => {
+      try {
+        await this.disableKeyboardIntroduction();
+      } catch (e) {
+        log.info(`Cannot disable Simulator keyboard introduction. Original error: ${e.message}`);
+      }
+    })();
   }
 
   /**


### PR DESCRIPTION
This call did fail randomly once while I was running tests on my computer. I assume this call could be async and should also not be breaking in case of a failure