### PR TITLE
feat: add setReduceTransparency

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -157,6 +157,16 @@ async function setReduceMotion (sim, reduceMotion = true) {
   }
 }
 
+async function setReduceTransparency (sim, reduceTransparency = true) {
+  log.debug(`Updating reduce tranceparency. Setting to ${reduceTransparency}.`);
+  const paths = await plistPaths(sim, 'accessibilitySettings');
+  for (const file of paths) {
+    await update(file, {
+      EnhancedBackgroundContrastEnabled: reduceTransparency ? 1 : 0
+    });
+  }
+}
+
 async function updateSafariGlobalSettings (sim, settingSet) {
   log.debug('Updating Safari global settings');
 
@@ -270,7 +280,7 @@ async function stub () {
 }
 
 export {
-  update, updateSettings, updateLocationSettings, setReduceMotion,
+  update, updateSettings, updateLocationSettings, setReduceMotion, setReduceTransparency,
   updateSafariUserSettings, updateSafariGlobalSettings, updateLocale, read,
   readSettings, stub,
 };

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -157,7 +157,7 @@ async function setReduceMotion (sim, reduceMotion = true) {
   }
 }
 
-async function setReduceTransparency (sim, reduceTransparency = true) {
+async function setReduceTransparency (sim, reduceTransparency) {
   log.debug(`Updating reduce tranceparency. Setting to ${reduceTransparency}.`);
   const paths = await plistPaths(sim, 'accessibilitySettings');
   for (const file of paths) {

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -777,7 +777,7 @@ class SimulatorXcode6 extends EventEmitter {
    *
    * @param {boolean} reduceMotion - Whether or not to enable it.
    */
-  async setReduceTransparency (reduceTransparency = true) {
+  async setReduceTransparency (reduceTransparency) {
     await settings.setReduceTransparency(this, reduceTransparency);
   }
 

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -778,10 +778,6 @@ class SimulatorXcode6 extends EventEmitter {
    * @param {boolean} reduceMotion - Whether or not to enable it.
    */
   async setReduceTransparency (reduceTransparency = true) {
-    if (await this.isFresh()) {
-      await this.launchAndQuit(false, STARTUP_TIMEOUT);
-    }
-
     await settings.setReduceTransparency(this, reduceTransparency);
   }
 

--- a/lib/simulator-xcode-6.js
+++ b/lib/simulator-xcode-6.js
@@ -773,6 +773,19 @@ class SimulatorXcode6 extends EventEmitter {
   }
 
   /**
+   * Enable/Disable reduce transparency.
+   *
+   * @param {boolean} reduceMotion - Whether or not to enable it.
+   */
+  async setReduceTransparency (reduceTransparency = true) {
+    if (await this.isFresh()) {
+      await this.launchAndQuit(false, STARTUP_TIMEOUT);
+    }
+
+    await settings.setReduceTransparency(this, reduceTransparency);
+  }
+
+  /**
    * Sets UI appearance style.
    * This function can only be called on a booted simulator.
    *

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -416,6 +416,22 @@ describe('advanced features', function () {
     });
   });
 
+  describe(`setReduceTransparency`, function () {
+    it('should check accessibility reduce transparency settings', async function () {
+      await sim.setReduceTransparency(true);
+      let fileSettings = await readSettings(sim, 'accessibilitySettings');
+      for (const [, settings] of _.toPairs(fileSettings)) {
+        settings.EnhancedBackgroundContrastEnabled.should.eql(1);
+      }
+
+      await sim.setReduceTransparency(false);
+      fileSettings = await readSettings(sim, 'accessibilitySettings');
+      for (const [, settings] of _.toPairs(fileSettings)) {
+        settings.EnhancedBackgroundContrastEnabled.should.eql(0);
+      }
+    });
+  });
+
   describe('updateSafariGlobalSettings', function () {
     it('should set an arbitrary preference on the global Safari plist', async function () {
       await sim.updateSafariGlobalSettings({

--- a/test/unit/settings-specs.js
+++ b/test/unit/settings-specs.js
@@ -322,16 +322,7 @@ describe('settings', function () {
       sinon.stub(settings, 'setReduceTransparency');
     });
 
-    it('should launch simulator if fresh before setting reduce transparency', async function () {
-      sinon.stub(sim, 'isFresh').returns(true);
-      sinon.stub(sim, 'launchAndQuit');
-      await sim.setReduceTransparency(true);
-      sim.launchAndQuit.calledOnce.should.eql(true);
-      settings.setReduceTransparency.calledOnce.should.eql(true);
-    });
-
-    it('should just set reduce transparency', async function () {
-      sinon.stub(sim, 'isFresh').returns(false);
+    it('should set reduce transparency', async function () {
       await sim.setReduceTransparency(true);
       settings.setReduceTransparency.calledOnce.should.eql(true);
     });

--- a/test/unit/settings-specs.js
+++ b/test/unit/settings-specs.js
@@ -309,4 +309,31 @@ describe('settings', function () {
       settings.setReduceMotion.calledOnce.should.eql(true);
     });
   });
+
+  describe('setReduceTransparency', function () {
+    let sim;
+    before(function () {
+      sim = new SimulatorXcode6();
+      sinon.stub(settings, 'setReduceTransparency');
+    });
+
+    afterEach(function () {
+      sinon.restore();
+      sinon.stub(settings, 'setReduceTransparency');
+    });
+
+    it('should launch simulator if fresh before setting reduce transparency', async function () {
+      sinon.stub(sim, 'isFresh').returns(true);
+      sinon.stub(sim, 'launchAndQuit');
+      await sim.setReduceTransparency(true);
+      sim.launchAndQuit.calledOnce.should.eql(true);
+      settings.setReduceTransparency.calledOnce.should.eql(true);
+    });
+
+    it('should just set reduce transparency', async function () {
+      sinon.stub(sim, 'isFresh').returns(false);
+      await sim.setReduceTransparency(true);
+      settings.setReduceTransparency.calledOnce.should.eql(true);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds setReduceTransparency function that allows to switch `Reduce Transparency` in accessibility preference.
Please see  https://github.com/appium/appium/issues/17905 for the background, and feel free to close this if this feature request doesn't make sense.

I found `ReduceMotion` is implemented with a different approach https://github.com/appium/WebDriverAgent/pull/202
I'm not sure which way is better though, I confirmed `EnhancedBackgroundContrastEnabled` can be changed in runtime and reflected immediately. So I chose this way but please let me know if WDA is better then I'll try to do it.