### PR TITLE
fix: udid reference in setAccess

### DIFF
--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -78,18 +78,19 @@ async function execWix (args) {
 /**
  * Sets permissions for the given application
  *
+ * @param {string} udid - udid of the target simulator device.
  * @param {string} bundleId - bundle identifier of the target application.
  * @param {Object} permissionsMapping - An object, where keys ar  service names
  * and values are corresponding state values. See https://github.com/wix/AppleSimulatorUtils
  * for more details on available service names and statuses.
  * @throws {Error} If there was an error while changing permissions.
  */
-async function setAccess (bundleId, permissionsMapping) {
+async function setAccess (udid, bundleId, permissionsMapping) {
   const permissionsArg = _.toPairs(permissionsMapping)
     .map((x) => `${x[0]}=${formatStatus(x[1])}`)
     .join(',');
   return await execWix([
-    '--byId', this.udid,
+    '--byId', udid,
     '--bundle', bundleId,
     '--setPermissions', permissionsArg,
   ]);
@@ -148,7 +149,7 @@ extensions.setPermission = async function setPermission (bundleId, permission, v
  */
 extensions.setPermissions = async function setPermissions (bundleId, permissionsMapping) {
   log.debug(`Setting access for '${bundleId}': ${JSON.stringify(permissionsMapping, null, 2)}`);
-  await setAccess(bundleId, permissionsMapping);
+  await setAccess(this.udid, bundleId, permissionsMapping);
 };
 
 /**


### PR DESCRIPTION
Found an issue in ruby's func test code:
https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=24363&view=logs&j=9ea0b8ba-2eaf-5ebd-f027-f9e150263999&t=2cce7409-2ec4-50f8-2653-6fd0ce207c6c

```
Minitest::UnexpectedError:         Selenium::WebDriver::Error::UnknownError: An unknown server-side error occurred while processing the command. Original error: Cannot read properties of undefined (reading 'udid')
            UnknownError: An unknown server-side error occurred while processing the command. Original error: Cannot read properties of undefined (reading 'udid')
```

---

The below one will be in https://github.com/appium/appium-ios-simulator/pull/351

I also wonder if the getAcccess might need to use https://github.com/wix/AppleSimulatorUtils as https://github.com/appium/appium-xcuitest-driver#mobile-getpermission.
Current script has `allowed` query, but it got `Original error: Error: in prepare, no such column: allowed (1)`? (This is another issue, but expected behavior as current implementation i guess)

For iOS 14+, maybe it needs to refer to `auth_value`.