### PR TITLE
fix: add ios 14 and above case

### DIFF
--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -110,11 +110,10 @@ async function setAccess (udid, bundleId, permissionsMapping) {
 async function getAccess (bundleId, serviceName, simDataRoot) {
   const internalServiceName = toInternalServiceName(serviceName);
   const dbPath = path.resolve(simDataRoot, 'Library', 'TCC', 'TCC.db');
-
   const getAccessStatus = async (statusPairs, statusKey) => {
     for (const [statusValue, status] of statusPairs) {
       const sql = `SELECT count(*) FROM 'access' ` +
-      `WHERE client='${bundleId}' AND ${statusKey}=${statusValue} AND service='${internalServiceName}'`;
+        `WHERE client='${bundleId}' AND ${statusKey}=${statusValue} AND service='${internalServiceName}'`;
       const count = await execSQLiteQuery(dbPath, sql);
       if (parseInt(count.split('=')[1], 10) > 0) {
         return status;

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -111,26 +111,31 @@ async function getAccess (bundleId, serviceName, simDataRoot) {
   const internalServiceName = toInternalServiceName(serviceName);
   const dbPath = path.resolve(simDataRoot, 'Library', 'TCC', 'TCC.db');
 
-  // iOS 14 and above
-  for (const [sqlValue, status] of [['0', STATUS_NO], ['2', STATUS_YES], ['3', STATUS_LIMITED]]) {
-    const sql = `SELECT count(*) FROM 'access' ` +
-    `WHERE client='${bundleId}' AND auth_value=${sqlValue} AND service='${internalServiceName}'`;
-    const count = await execSQLiteQuery(dbPath, sql);
-    if (parseInt(count.split('=')[1], 10) > 0) {
-      return status;
+  const getAcccessStatus = async (statusPairs, statusKey) => {
+    for (const [statusValue, status] of statusPairs) {
+      const sql = `SELECT count(*) FROM 'access' ` +
+      `WHERE client='${bundleId}' AND ${statusKey}=${statusValue} AND service='${internalServiceName}'`;
+      const count = await execSQLiteQuery(dbPath, sql);
+      if (parseInt(count.split('=')[1], 10) > 0) {
+        return status;
+      }
     }
-  }
+    return STATUS_UNSET;
+  };
 
-  // iOS 13 and lower
-  // for (const [sqlValue, status] of [['0', STATUS_NO], ['1', STATUS_YES]]) {
-  //   const sql = `SELECT count(*) FROM 'access' ` +
-  //     `WHERE client='${bundleId}' AND allowed=${sqlValue} AND service='${internalServiceName}'`;
-  //   const count = await execSQLiteQuery(dbPath, sql);
-  //   if (parseInt(count.split('=')[1], 10) > 0) {
-  //     return status;
-  //   }
-  // }
-  return STATUS_UNSET;
+  try {
+    // iOS 14 and above
+    return await getAcccessStatus(
+      [['0', STATUS_NO], ['2', STATUS_YES], ['3', STATUS_LIMITED]],
+      'auth_value'
+    );
+  } catch {
+    // iOS 13 and below
+    return await getAcccessStatus(
+      [['0', STATUS_NO], ['1', STATUS_YES]],
+      'allowed'
+    );
+  }
 }
 
 

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -128,11 +128,11 @@ async function getAccess (bundleId, serviceName, simDataRoot) {
   const xcodeVersion = await getVersion(true);
   return xcodeVersion.major >= 13 ?
     await getAccessStatus(
-      [['0', UNSET.NO], ['2', UNSET.YES], ['3', STATUS.LIMITED]],
+      [['0', STATUS.NO], ['2', STATUS.YES], ['3', STATUS.LIMITED]],
       'auth_value'
     ) :
     await getAccessStatus(
-      [['0', UNSET.NO], ['1', UNSET.YES]],
+      [['0', STATUS.NO], ['1', STATUS.YES]],
       'allowed'
     );
 }

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -132,7 +132,7 @@ async function getAccess (bundleId, serviceName, simDataRoot) {
     return await getAccessStatus(
       [['0', STATUS.NO], ['2', STATUS.YES], ['3', STATUS.LIMITED]],
       'auth_value'
-    )
+    );
   } catch {
     return await getAccessStatus(
       [['0', STATUS.NO], ['1', STATUS.YES]],

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -111,7 +111,7 @@ async function getAccess (bundleId, serviceName, simDataRoot) {
   const internalServiceName = toInternalServiceName(serviceName);
   const dbPath = path.resolve(simDataRoot, 'Library', 'TCC', 'TCC.db');
 
-  const getAcccessStatus = async (statusPairs, statusKey) => {
+  const getAccessStatus = async (statusPairs, statusKey) => {
     for (const [statusValue, status] of statusPairs) {
       const sql = `SELECT count(*) FROM 'access' ` +
       `WHERE client='${bundleId}' AND ${statusKey}=${statusValue} AND service='${internalServiceName}'`;
@@ -125,13 +125,13 @@ async function getAccess (bundleId, serviceName, simDataRoot) {
 
   try {
     // iOS 14 and above
-    return await getAcccessStatus(
+    return await getAccessStatus(
       [['0', STATUS_NO], ['2', STATUS_YES], ['3', STATUS_LIMITED]],
       'auth_value'
     );
   } catch {
     // iOS 13 and below
-    return await getAcccessStatus(
+    return await getAccessStatus(
       [['0', STATUS_NO], ['1', STATUS_YES]],
       'allowed'
     );

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -78,18 +78,19 @@ async function execWix (args) {
 /**
  * Sets permissions for the given application
  *
+ * @param {string} udid - udid of the target simulator device.
  * @param {string} bundleId - bundle identifier of the target application.
  * @param {Object} permissionsMapping - An object, where keys ar  service names
  * and values are corresponding state values. See https://github.com/wix/AppleSimulatorUtils
  * for more details on available service names and statuses.
  * @throws {Error} If there was an error while changing permissions.
  */
-async function setAccess (bundleId, permissionsMapping) {
+async function setAccess (udid, bundleId, permissionsMapping) {
   const permissionsArg = _.toPairs(permissionsMapping)
     .map((x) => `${x[0]}=${formatStatus(x[1])}`)
     .join(',');
   return await execWix([
-    '--byId', this.udid,
+    '--byId', udid,
     '--bundle', bundleId,
     '--setPermissions', permissionsArg,
   ]);
@@ -148,7 +149,7 @@ extensions.setPermission = async function setPermission (bundleId, permission, v
  */
 extensions.setPermissions = async function setPermissions (bundleId, permissionsMapping) {
   log.debug(`Setting access for '${bundleId}': ${JSON.stringify(permissionsMapping, null, 2)}`);
-  await setAccess(bundleId, permissionsMapping);
+  await setAccess(this.udid, bundleId, permissionsMapping);
 };
 
 /**

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -7,6 +7,7 @@ import path from 'path';
 const STATUS_UNSET = 'unset';
 const STATUS_NO = 'no';
 const STATUS_YES = 'yes';
+const STATUS_LIMITED = 'limited';
 const WIX_SIM_UTILS = 'applesimutils';
 const SERVICES = Object.freeze({
   calendar: 'kTCCServiceCalendar',
@@ -103,20 +104,32 @@ async function setAccess (udid, bundleId, permissionsMapping) {
  * @param {string} serviceName - the name of the service. Should be one of
  * `SERVICES` keys.
  * @param {string} simDataRoot - the path to Simulator `data` root
- * @returns {string} - The current status: yes/no/unset
+ * @returns {string} - The current status: yes/no/unset/limited
  * @throws {Error} If there was an error while retrieving permissions.
  */
 async function getAccess (bundleId, serviceName, simDataRoot) {
   const internalServiceName = toInternalServiceName(serviceName);
   const dbPath = path.resolve(simDataRoot, 'Library', 'TCC', 'TCC.db');
-  for (const [sqlValue, status] of [['0', STATUS_NO], ['1', STATUS_YES]]) {
+
+  // iOS 14 and above
+  for (const [sqlValue, status] of [['0', STATUS_NO], ['2', STATUS_YES], ['3', STATUS_LIMITED]]) {
     const sql = `SELECT count(*) FROM 'access' ` +
-      `WHERE client='${bundleId}' AND allowed=${sqlValue} AND service='${internalServiceName}'`;
+    `WHERE client='${bundleId}' AND auth_value=${sqlValue} AND service='${internalServiceName}'`;
     const count = await execSQLiteQuery(dbPath, sql);
     if (parseInt(count.split('=')[1], 10) > 0) {
       return status;
     }
   }
+
+  // iOS 13 and lower
+  // for (const [sqlValue, status] of [['0', STATUS_NO], ['1', STATUS_YES]]) {
+  //   const sql = `SELECT count(*) FROM 'access' ` +
+  //     `WHERE client='${bundleId}' AND allowed=${sqlValue} AND service='${internalServiceName}'`;
+  //   const count = await execSQLiteQuery(dbPath, sql);
+  //   if (parseInt(count.split('=')[1], 10) > 0) {
+  //     return status;
+  //   }
+  // }
   return STATUS_UNSET;
 }
 
@@ -133,7 +146,7 @@ const extensions = {};
  * @param {string} value - The desired status for the service.
  * @throws {Error} If there was an error while changing permission.
  */
-extensions.setPermission = async function setPermission (bundleId, permission, value) {
+extensions.c = async function setPermission (bundleId, permission, value) {
   await this.setPermissions(bundleId, {[permission]: value});
 };
 

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -4,10 +4,13 @@ import { fs, util } from '@appium/support';
 import { exec } from 'teen_process';
 import path from 'path';
 
-const STATUS_UNSET = 'unset';
-const STATUS_NO = 'no';
-const STATUS_YES = 'yes';
-const STATUS_LIMITED = 'limited';
+const STATUS = Object.freeze({
+  UNSET: 'unset',
+  NO: 'no',
+  YES: 'yes',
+  LIMITED: 'limited',
+});
+
 const WIX_SIM_UTILS = 'applesimutils';
 const SERVICES = Object.freeze({
   calendar: 'kTCCServiceCalendar',
@@ -34,7 +37,7 @@ function toInternalServiceName (serviceName) {
 }
 
 function formatStatus (status) {
-  return [STATUS_UNSET, STATUS_NO].includes(status) ? _.toUpper(status) : status;
+  return [STATUS.UNSET, STATUS.NO].includes(status) ? _.toUpper(status) : status;
 }
 
 /**
@@ -119,24 +122,20 @@ async function getAccess (bundleId, serviceName, simDataRoot) {
         return status;
       }
     }
-    return STATUS_UNSET;
+    return STATUS.UNSET;
   };
 
-  try {
-    // iOS 14 and above
-    return await getAccessStatus(
-      [['0', STATUS_NO], ['2', STATUS_YES], ['3', STATUS_LIMITED]],
+  const xcodeVersion = await getVersion(true);
+  return xcodeVersion.major >= 13 ?
+    await getAccessStatus(
+      [['0', UNSET.NO], ['2', UNSET.YES], ['3', STATUS.LIMITED]],
       'auth_value'
-    );
-  } catch {
-    // iOS 13 and below
-    return await getAccessStatus(
-      [['0', STATUS_NO], ['1', STATUS_YES]],
+    ) :
+    await getAccessStatus(
+      [['0', UNSET.NO], ['1', UNSET.YES]],
       'allowed'
     );
-  }
 }
-
 
 const extensions = {};
 

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -125,16 +125,20 @@ async function getAccess (bundleId, serviceName, simDataRoot) {
     return STATUS.UNSET;
   };
 
-  const xcodeVersion = await getVersion(true);
-  return xcodeVersion.major >= 13 ?
-    await getAccessStatus(
+  // 'auth_value' existence depends on the OS version rather than Xcode version.
+  // Thus here check the newer one first, then fallback to the older version way.
+  try {
+    // iOS 14+
+    return await getAccessStatus(
       [['0', STATUS.NO], ['2', STATUS.YES], ['3', STATUS.LIMITED]],
       'auth_value'
-    ) :
-    await getAccessStatus(
+    )
+  } catch {
+    return await getAccessStatus(
       [['0', STATUS.NO], ['1', STATUS.YES]],
       'allowed'
     );
+  }
 }
 
 const extensions = {};

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -146,7 +146,7 @@ const extensions = {};
  * @param {string} value - The desired status for the service.
  * @throws {Error} If there was an error while changing permission.
  */
-extensions.c = async function setPermission (bundleId, permission, value) {
+extensions.setPermission = async function setPermission (bundleId, permission, value) {
   await this.setPermissions(bundleId, {[permission]: value});
 };
 


### PR DESCRIPTION
This PR is to fix getAcccess for iOS 14+ after https://github.com/appium/appium-ios-simulator/pull/350

https://github.com/wix/AppleSimulatorUtils/blob/5467857407da4653305af119b2486051664a4f97/applesimutils/applesimutils/SetServicePermission.m

Should handle iOS version, or probably try iOs 14's first then fallback to existing one if an exception occurs only