### PR TITLE
fix: retrieve an appropriate unix socket path

### DIFF
--- a/lib/simulator-xcode-9.3.js
+++ b/lib/simulator-xcode-9.3.js
@@ -18,27 +18,8 @@ class SimulatorXcode93 extends SimulatorXcode9 {
       return this.webInspectorSocket;
     }
 
-    // lsof -aUc launchd_sim
-    // gives a set of records like:
-    //   COMMAND     PID      USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
-    //   launchd_s 81243 mwakizaka    3u  unix 0x9461828ef425ac31      0t0      /private/tmp/com.apple.launchd.ULf9wKNtd5/com.apple.webinspectord_sim.socket
-    //   launchd_s 81243 mwakizaka    4u  unix 0x9461828ef425bc99      0t0      /tmp/com.apple.CoreSimulator.SimDevice.F1191A22-11DD-408E-8CAF-0BC4A8F79E3B/syslogsock
-    //   launchd_s 81243 mwakizaka    6u  unix 0x9461828ef27d4c39      0t0      ->0x9461828ef27d4b71
-    //   launchd_s 81243 mwakizaka    7u  unix 0x9461828ef425dd69      0t0      ->0x9461828ef27d5021
-    //   launchd_s 81243 mwakizaka    8u  unix 0x9461828ef425b4c9      0t0      /private/tmp/com.apple.launchd.88z8qTMoJA/Listeners
-    //   launchd_s 81243 mwakizaka    9u  unix 0x9461828ef425be29      0t0      /private/tmp/com.apple.launchd.rbqFyGyXrT/com.apple.testmanagerd.unix-domain.socket
-    //   launchd_s 81243 mwakizaka   10u  unix 0x9461828ef425b4c9      0t0      /private/tmp/com.apple.launchd.88z8qTMoJA/Listeners
-    //   launchd_s 81243 mwakizaka   11u  unix 0x9461828ef425c081      0t0      /private/tmp/com.apple.launchd.zHidszZQUZ/com.apple.testmanagerd.remote-automation.unix-domain.socket
-    //   launchd_s 81243 mwakizaka   12u  unix 0x9461828ef425def9      0t0      ->0x9461828ef425de31
-    //   launchd_s 35621 mwakizaka    4u  unix 0x7b7dbedd6d63253f      0t0      /tmp/com.apple.CoreSimulator.SimDevice.150983FD-82FB-4A7B-86DC-D3D264DD90E5/syslogsock
-    //   launchd_s 35621 mwakizaka    5u  unix 0x7b7dbedd6d62f727      0t0      /private/tmp/com.apple.launchd.zuM1XDJcwr/com.apple.webinspectord_sim.socket
-    //   launchd_s 35621 mwakizaka    9u  unix 0x7b7dbedd6d632607      0t0      /private/tmp/com.apple.launchd.KbYwOrA36E/Listeners
-    //   launchd_s 35621 mwakizaka   10u  unix 0x7b7dbedd6d62f727      0t0      /private/tmp/com.apple.launchd.zuM1XDJcwr/com.apple.webinspectord_sim.socket
-    //   launchd_s 35621 mwakizaka   11u  unix 0x7b7dbedd6d62e6bf      0t0      /private/tmp/com.apple.launchd.7wTVfXC9QX/com.apple.testmanagerd.unix-domain.socket
-    //   launchd_s 35621 mwakizaka   12u  unix 0x7b7dbedd6d632607      0t0      /private/tmp/com.apple.launchd.KbYwOrA36E/Listeners
-    //   launchd_s 35621 mwakizaka   13u  unix 0x7b7dbedd6d62e84f      0t0      /private/tmp/com.apple.launchd.g7KQlSsvXT/com.apple.testmanagerd.remote-automation.unix-domain.socket
-    //   launchd_s 35621 mwakizaka   15u  unix 0x7b7dbedd6d62e6bf      0t0      /private/tmp/com.apple.launchd.7wTVfXC9QX/com.apple.testmanagerd.unix-domain.socket
-    //   launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/tmp/com.apple.launchd.g7KQlSsvXT/com.apple.testmanagerd.remote-automation.unix-domain.socket
+    // lsof -aUc launchd_sim gives a set of records like
+    // https://github.com/appium/appium-ios-simulator/commit/c00901a9ddea178c5581a7a57d96d8cee3f17c59#diff-2be09dd2ea01cfd6bbbd73e10bc468da782a297365eec706999fc3709c01478dR102
     // these _appear_ to always be grouped together by PID for each simulator.
     // Therefore, by obtaining simulator PID with an expected simulator UDID,
     // we can get the correct `com.apple.webinspectord_sim.socket`

--- a/lib/simulator-xcode-9.3.js
+++ b/lib/simulator-xcode-9.3.js
@@ -1,5 +1,6 @@
 import SimulatorXcode9 from './simulator-xcode-9';
 import { exec } from 'teen_process';
+import log from './logger';
 
 
 class SimulatorXcode93 extends SimulatorXcode9 {
@@ -43,12 +44,17 @@ class SimulatorXcode93 extends SimulatorXcode9 {
     // we can get the correct `com.apple.webinspectord_sim.socket`
     // without depending on the order of `lsof -aUc launchd_sim` result.
     const {stdout} = await exec('lsof', ['-aUc', 'launchd_sim']);
-    const udidMatch = stdout.match(new RegExp('([0-9]{1,5}).+' + this.udid));
+    const udidPattern = `([0-9]{1,5}).+${this.udid}`;
+    const udidMatch = stdout.match(new RegExp(udidPattern));
     if (!udidMatch) {
+      log.debug(`Failed to get Web Inspector socket with ${udidPattern} pattern`);
       return null;
     }
-    const pidMatch = stdout.match(new RegExp(udidMatch[1] + '.+\\s+(\\S+com.apple.webinspectord_sim.socket)'));
+
+    const pidPattern = `${udidMatch[1]}.+\\s+(\\S+com.apple.webinspectord_sim.socket)`;
+    const pidMatch = stdout.match(new RegExp(pidPattern));
     if (!pidMatch) {
+      log.debug(`Failed to get Web Inspector socket with ${pidPattern} pattern`);
       return null;
     }
     this.webInspectorSocket = pidMatch[1];

--- a/lib/simulator-xcode-9.3.js
+++ b/lib/simulator-xcode-9.3.js
@@ -2,9 +2,6 @@ import SimulatorXcode9 from './simulator-xcode-9';
 import { exec } from 'teen_process';
 
 
-// https://regex101.com/r/MEL55t/1
-const WEBINSPECTOR_SOCKET_REGEXP = /\s+(\S+com\.apple\.webinspectord_sim\.socket)/;
-
 class SimulatorXcode93 extends SimulatorXcode9 {
   constructor (udid, xcodeVersion) {
     super(udid, xcodeVersion);
@@ -22,30 +19,40 @@ class SimulatorXcode93 extends SimulatorXcode9 {
 
     // lsof -aUc launchd_sim
     // gives a set of records like:
-    //   launchd_s 69760 isaac    3u  unix 0x57aa4fceea3937f3      0t0      /private/tmp/com.apple.CoreSimulator.SimDevice.D7082A5C-34B5-475C-994E-A21534423B9E/syslogsock
-    //   launchd_s 69760 isaac    5u  unix 0x57aa4fceea395f03      0t0      /private/tmp/com.apple.launchd.2B2u8CkN8S/Listeners
-    //   launchd_s 69760 isaac    6u  unix 0x57aa4fceea39372b      0t0      ->0x57aa4fceea3937f3
-    //   launchd_s 69760 isaac    8u  unix 0x57aa4fceea39598b      0t0      /private/tmp/com.apple.launchd.2j5k1TMh6i/com.apple.webinspectord_sim.socket
-    //   launchd_s 69760 isaac    9u  unix 0x57aa4fceea394c43      0t0      /private/tmp/com.apple.launchd.4zm9JO9KEs/com.apple.testmanagerd.unix-domain.socket
-    //   launchd_s 69760 isaac   10u  unix 0x57aa4fceea395f03      0t0      /private/tmp/com.apple.launchd.2B2u8CkN8S/Listeners
-    //   launchd_s 69760 isaac   11u  unix 0x57aa4fceea39598b      0t0      /private/tmp/com.apple.launchd.2j5k1TMh6i/com.apple.webinspectord_sim.socket
-    //   launchd_s 69760 isaac   12u  unix 0x57aa4fceea394c43      0t0      /private/tmp/com.apple.launchd.4zm9JO9KEs/com.apple.testmanagerd.unix-domain.socket
-    // these _appear_ to always be grouped together (so, the records for the particular sim are all in a group, before the next sim, etc.)
-    // so starting from the correct UDID, we ought to be able to pull the next record with `com.apple.webinspectord_sim.socket` to get the correct socket
-    let {stdout} = await exec('lsof', ['-aUc', 'launchd_sim']);
-    for (let record of stdout.split('com.apple.CoreSimulator.SimDevice.')) {
-      if (!record.includes(this.udid)) {
-        continue;
-      }
-      const match = WEBINSPECTOR_SOCKET_REGEXP.exec(record);
-      if (!match) {
-        return null;
-      }
-      this.webInspectorSocket = match[1];
-      return this.webInspectorSocket;
+    //   COMMAND     PID      USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+    //   launchd_s 81243 mwakizaka    3u  unix 0x9461828ef425ac31      0t0      /private/tmp/com.apple.launchd.ULf9wKNtd5/com.apple.webinspectord_sim.socket
+    //   launchd_s 81243 mwakizaka    4u  unix 0x9461828ef425bc99      0t0      /tmp/com.apple.CoreSimulator.SimDevice.F1191A22-11DD-408E-8CAF-0BC4A8F79E3B/syslogsock
+    //   launchd_s 81243 mwakizaka    6u  unix 0x9461828ef27d4c39      0t0      ->0x9461828ef27d4b71
+    //   launchd_s 81243 mwakizaka    7u  unix 0x9461828ef425dd69      0t0      ->0x9461828ef27d5021
+    //   launchd_s 81243 mwakizaka    8u  unix 0x9461828ef425b4c9      0t0      /private/tmp/com.apple.launchd.88z8qTMoJA/Listeners
+    //   launchd_s 81243 mwakizaka    9u  unix 0x9461828ef425be29      0t0      /private/tmp/com.apple.launchd.rbqFyGyXrT/com.apple.testmanagerd.unix-domain.socket
+    //   launchd_s 81243 mwakizaka   10u  unix 0x9461828ef425b4c9      0t0      /private/tmp/com.apple.launchd.88z8qTMoJA/Listeners
+    //   launchd_s 81243 mwakizaka   11u  unix 0x9461828ef425c081      0t0      /private/tmp/com.apple.launchd.zHidszZQUZ/com.apple.testmanagerd.remote-automation.unix-domain.socket
+    //   launchd_s 81243 mwakizaka   12u  unix 0x9461828ef425def9      0t0      ->0x9461828ef425de31
+    //   launchd_s 35621 mwakizaka    4u  unix 0x7b7dbedd6d63253f      0t0      /tmp/com.apple.CoreSimulator.SimDevice.150983FD-82FB-4A7B-86DC-D3D264DD90E5/syslogsock
+    //   launchd_s 35621 mwakizaka    5u  unix 0x7b7dbedd6d62f727      0t0      /private/tmp/com.apple.launchd.zuM1XDJcwr/com.apple.webinspectord_sim.socket
+    //   launchd_s 35621 mwakizaka    9u  unix 0x7b7dbedd6d632607      0t0      /private/tmp/com.apple.launchd.KbYwOrA36E/Listeners
+    //   launchd_s 35621 mwakizaka   10u  unix 0x7b7dbedd6d62f727      0t0      /private/tmp/com.apple.launchd.zuM1XDJcwr/com.apple.webinspectord_sim.socket
+    //   launchd_s 35621 mwakizaka   11u  unix 0x7b7dbedd6d62e6bf      0t0      /private/tmp/com.apple.launchd.7wTVfXC9QX/com.apple.testmanagerd.unix-domain.socket
+    //   launchd_s 35621 mwakizaka   12u  unix 0x7b7dbedd6d632607      0t0      /private/tmp/com.apple.launchd.KbYwOrA36E/Listeners
+    //   launchd_s 35621 mwakizaka   13u  unix 0x7b7dbedd6d62e84f      0t0      /private/tmp/com.apple.launchd.g7KQlSsvXT/com.apple.testmanagerd.remote-automation.unix-domain.socket
+    //   launchd_s 35621 mwakizaka   15u  unix 0x7b7dbedd6d62e6bf      0t0      /private/tmp/com.apple.launchd.7wTVfXC9QX/com.apple.testmanagerd.unix-domain.socket
+    //   launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/tmp/com.apple.launchd.g7KQlSsvXT/com.apple.testmanagerd.remote-automation.unix-domain.socket
+    // these _appear_ to always be grouped together by PID for each simulator.
+    // Therefore, by obtaining simulator PID with an expected simulator UDID,
+    // we can get the correct `com.apple.webinspectord_sim.socket`
+    // without depending on the order of `lsof -aUc launchd_sim` result.
+    const {stdout} = await exec('lsof', ['-aUc', 'launchd_sim']);
+    const udidMatch = stdout.match(new RegExp('([0-9]{1,5}).+' + this.udid));
+    if (!udidMatch) {
+      return null;
     }
-
-    return null;
+    const pidMatch = stdout.match(new RegExp(udidMatch[1] + '.+\\s+(\\S+com.apple.webinspectord_sim.socket)'));
+    if (!pidMatch) {
+      return null;
+    }
+    this.webInspectorSocket = pidMatch[1];
+    return this.webInspectorSocket;
   }
 }
 

--- a/lib/simulator-xcode-9.3.js
+++ b/lib/simulator-xcode-9.3.js
@@ -47,14 +47,14 @@ class SimulatorXcode93 extends SimulatorXcode9 {
     const udidPattern = `([0-9]{1,5}).+${this.udid}`;
     const udidMatch = stdout.match(new RegExp(udidPattern));
     if (!udidMatch) {
-      log.debug(`Failed to get Web Inspector socket with ${udidPattern} pattern`);
+      log.debug(`Failed to get Web Inspector socket. lsof result: ${stdout}`);
       return null;
     }
 
     const pidPattern = `${udidMatch[1]}.+\\s+(\\S+com.apple.webinspectord_sim.socket)`;
     const pidMatch = stdout.match(new RegExp(pidPattern));
     if (!pidMatch) {
-      log.debug(`Failed to get Web Inspector socket with ${pidPattern} pattern`);
+      log.debug(`Failed to get Web Inspector socket. lsof result: ${stdout}`);
       return null;
     }
     this.webInspectorSocket = pidMatch[1];

--- a/lib/simulator-xcode-9.3.js
+++ b/lib/simulator-xcode-9.3.js
@@ -51,7 +51,7 @@ class SimulatorXcode93 extends SimulatorXcode9 {
       return null;
     }
 
-    const pidPattern = `${udidMatch[1]}.+\\s+(\\S+com.apple.webinspectord_sim.socket)`;
+    const pidPattern = `${udidMatch[1]}.+\\s+(\\S+com\\.apple\\.webinspectord_sim\\.socket)`;
     const pidMatch = stdout.match(new RegExp(pidPattern));
     if (!pidMatch) {
       log.debug(`Failed to get Web Inspector socket. lsof result: ${stdout}`);

--- a/test/unit/simulator-specs.js
+++ b/test/unit/simulator-specs.js
@@ -121,6 +121,8 @@ launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/
 
     beforeEach(function () {
       sinon.stub(teenProcess, 'exec').callsFake(() => ({ stdout }));
+      const xcodeVersion = {major: 9, versionString: '9.3.0'};
+      xcodeMock.expects('getVersion').atLeast(1).returns(B.resolve(xcodeVersion));
     });
     afterEach(function () {
       teenProcess.exec.restore();
@@ -133,9 +135,6 @@ launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/
 
     testParams.forEach(({udid, line, expected}) => {
       it(`should find a Web Inspector socket when it appears at the ${line} line of grouped records`, async function () {
-        const xcodeVersion = {major: 9, versionString: '9.3.0'};
-        xcodeMock.expects('getVersion').atLeast(1).returns(B.resolve(xcodeVersion));
-
         const sim = await getSimulator(udid);
         const webInspectorSocket = await sim.getWebInspectorSocket();
         webInspectorSocket.should.equal(expected);
@@ -143,9 +142,6 @@ launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/
     });
 
     it(`should assign webInspectorSocket value only once`, async function () {
-      const xcodeVersion = {major: 9, versionString: '9.3.0'};
-      xcodeMock.expects('getVersion').atLeast(1).returns(B.resolve(xcodeVersion));
-
       const sim = await getSimulator(testParams[0].udid);
       await sim.getWebInspectorSocket();
       await sim.getWebInspectorSocket();

--- a/test/unit/simulator-specs.js
+++ b/test/unit/simulator-specs.js
@@ -119,10 +119,10 @@ launchd_s 35621 mwakizaka   13u  unix 0x7b7dbedd6d62e84f      0t0      /private/
 launchd_s 35621 mwakizaka   15u  unix 0x7b7dbedd6d62e6bf      0t0      /private/tmp/com.apple.launchd.7wTVfXC9QX/com.apple.testmanagerd.unix-domain.socket
 launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/tmp/com.apple.launchd.g7KQlSsvXT/com.apple.testmanagerd.remote-automation.unix-domain.socket`;
 
-    before(function () {
+    beforeEach(function () {
       sinon.stub(teenProcess, 'exec').callsFake(() => ({ stdout }));
     });
-    after(function () {
+    afterEach(function () {
       teenProcess.exec.restore();
     });
 
@@ -140,6 +140,16 @@ launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/
         const webInspectorSocket = await sim.getWebInspectorSocket();
         webInspectorSocket.should.equal(expected);
       });
+    });
+
+    it(`should assign webInspectorSocket value only once`, async function () {
+      const xcodeVersion = {major: 9, versionString: '9.3.0'};
+      xcodeMock.expects('getVersion').atLeast(1).returns(B.resolve(xcodeVersion));
+
+      const sim = await getSimulator(testParams[0].udid);
+      await sim.getWebInspectorSocket();
+      await sim.getWebInspectorSocket();
+      teenProcess.exec.callCount.should.equal(1);
     });
   });
 });

--- a/test/unit/simulator-specs.js
+++ b/test/unit/simulator-specs.js
@@ -132,7 +132,7 @@ launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/
     ];
 
     testParams.forEach(({udid, line, expected}) => {
-      it(`should find a Web Inspector socket when it appears at the ${line} line of grouped outputs`, async function () {
+      it(`should find a Web Inspector socket when it appears at the ${line} line of grouped records`, async function () {
         const xcodeVersion = {major: 9, versionString: '9.3.0'};
         xcodeMock.expects('getVersion').atLeast(1).returns(B.resolve(xcodeVersion));
 


### PR DESCRIPTION
We have assumed that we always obtain `lsof -aUc launchd_sim` result in a specific order. (e.g. an output line like `/com.apple.CoreSimulator.SimDevice.D7082A5C-34B5-475C-994E-A21534423B9E` always comes before `com.apple.webinspectord_sim.socket` line) However, sometimes the assumption seems to be wrong (as far as I checked it can happen since Xcode 13.4.1. I haven't seen this phenomenon on Xcode 13.1 or earlier). Therefore, it is most likely necessary to obtain an appropriate unix socket path without depending on the order of the output.