### PR TITLE
chore: update links for set-simulator-location

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ assert.equal('Shutdown', (await sim.stat()).state);
 
 The following tools and utilities are not mandatory, but could be used by the appium-ios-simulator, if installed locally, to extend its functionality:
 
-- [Lyft](https://github.com/lyft)
+- [Mobile Native Foundation](https://github.com/MobileNativeFoundation)
 - [IDB](https://github.com/facebook/idb)
 - [AppleSimulatorUtils](https://github.com/wix/AppleSimulatorUtils)
 

--- a/lib/extensions/geolocation.js
+++ b/lib/extensions/geolocation.js
@@ -30,8 +30,8 @@ async function setLocationWithLyft (udid, latitude, longitude) {
   } catch (e) {
     throw new Error(`'${LYFT_SET_LOCATION}' binary has not been found in your PATH. ` +
       'Please install it as "brew install lyft/formulae/set-simulator-location" by brew or ' +
-      'read https://github.com/lyft/set-simulator-location to set the binary by manual to ' +
-      'be able to set geolocation by the library.');
+      'read https://github.com/MobileNativeFoundation/set-simulator-location to set ' +
+      'the binary by manual to be able to set geolocation by the library.');
   }
 
   try {


### PR DESCRIPTION
https://github.com/MobileNativeFoundation/set-simulator-location is now under Mobile Native Foundation from Lyft