### PR TITLE
fix: isAppInstalled in lib/simulator-xcode-15.js

### DIFF
--- a/lib/simulator-xcode-15.js
+++ b/lib/simulator-xcode-15.js
@@ -16,7 +16,7 @@ class SimulatorXcode15 extends SimulatorXcode14 {
       return this._systemAppBundleIds;
     }
 
-    const appsRoot = path.resolve((await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT')).trim(), 'Applications');
+    const appsRoot = path.resolve(_.trim(await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT')), 'Applications');
     const fetchBundleId = async (appRoot) => {
       const {stdout} = await exec('/usr/libexec/PlistBuddy', [
         '-c', 'print CFBundleIdentifier', path.resolve(appRoot, 'Info.plist')
@@ -57,7 +57,7 @@ class SimulatorXcode15 extends SimulatorXcode14 {
    */
   async getLaunchDaemonsRoot () {
     return path.resolve(
-      (await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT')).trim(),
+      _.trim(await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT')),
       'System/Library/LaunchDaemons'
     );
   }

--- a/lib/simulator-xcode-15.js
+++ b/lib/simulator-xcode-15.js
@@ -16,7 +16,7 @@ class SimulatorXcode15 extends SimulatorXcode14 {
       return this._systemAppBundleIds;
     }
 
-    const appsRoot = path.resolve(await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT'), 'Applications');
+    const appsRoot = path.resolve((await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT')).trim(), 'Applications');
     const fetchBundleId = async (appRoot) => {
       const {stdout} = await exec('/usr/libexec/PlistBuddy', [
         '-c', 'print CFBundleIdentifier', path.resolve(appRoot, 'Info.plist')
@@ -57,7 +57,7 @@ class SimulatorXcode15 extends SimulatorXcode14 {
    */
   async getLaunchDaemonsRoot () {
     return path.resolve(
-      await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT'),
+      (await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT')).trim(),
       'System/Library/LaunchDaemons'
     );
   }

--- a/lib/simulator-xcode-15.js
+++ b/lib/simulator-xcode-15.js
@@ -18,8 +18,12 @@ class SimulatorXcode15 extends SimulatorXcode14 {
 
     const appsRoot = path.resolve(_.trim(await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT')), 'Applications');
     const fetchBundleId = async (appRoot) => {
+      const infoPlistPath = path.resolve(appRoot, 'Info.plist');
+      if (!(await fs.exists(infoPlistPath))) {
+        return '';
+      }
       const {stdout} = await exec('/usr/libexec/PlistBuddy', [
-        '-c', 'print CFBundleIdentifier', path.resolve(appRoot, 'Info.plist')
+        '-c', 'print CFBundleIdentifier', infoPlistPath
       ]);
       return _.trim(stdout);
     };


### PR DESCRIPTION
According to https://github.com/appium/appium/issues/18749#issuecomment-1644903756 , probably `await this.simctl.getEnv('IPHONE_SIMULATOR_ROOT')` included a new line. Then, the built path could have `\n`.

It might be safe to do `trim()`