### PR TITLE
feat: Add setAutoFillPasswordsEnabled function

### DIFF
--- a/lib/extensions/settings.js
+++ b/lib/extensions/settings.js
@@ -72,4 +72,15 @@ extensions.configureLocalization = async function configureLocalization () {
   throw new Error(`Xcode SDK '${this.xcodeVersion}' is too old to configure the Simulator locale`);
 };
 
+/**
+ * Updates Auto Fill Passwords setting state.
+ *
+ * @param {boolean} isEnabled Whether to enable or disable the setting.
+ */
+extensions.setAutoFillPasswordsEnabled = async function setAutoFillPasswordsEnabled (isEnabled) {
+  return await this.updateSettings('com.apple.WebUI', {
+    AutoFillPasswords: Number(isEnabled ? 1 : 0)
+  });
+};
+
 export default extensions;

--- a/lib/extensions/settings.js
+++ b/lib/extensions/settings.js
@@ -77,9 +77,9 @@ extensions.configureLocalization = async function configureLocalization () {
  *
  * @param {boolean} isEnabled Whether to enable or disable the setting.
  */
-extensions.setAutoFillPasswordsEnabled = async function setAutoFillPasswordsEnabled (isEnabled) {
+extensions.setAutoFillPasswords = async function setAutoFillPasswords (isEnabled) {
   return await this.updateSettings('com.apple.WebUI', {
-    AutoFillPasswords: Number(isEnabled ? 1 : 0)
+    AutoFillPasswords: Number(isEnabled)
   });
 };
 

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -322,6 +322,13 @@ describe('advanced features', function () {
     });
   });
 
+  describe(`setAutoFillPasswordsEnabled`, function () {
+    it('should update AutoFill Passwords settings', async function () {
+      await sim.setAutoFillPasswordsEnabled(true);
+      await sim.setAutoFillPasswordsEnabled(false);
+    });
+  });
+
   describe('Safari', function () {
     it('should scrub Safari', async function () {
       if (xcodeVersion.major === 13 && process.env.CI) {

--- a/test/functional/simulator-e2e-specs.js
+++ b/test/functional/simulator-e2e-specs.js
@@ -322,10 +322,10 @@ describe('advanced features', function () {
     });
   });
 
-  describe(`setAutoFillPasswordsEnabled`, function () {
+  describe(`setAutoFillPasswords`, function () {
     it('should update AutoFill Passwords settings', async function () {
-      await sim.setAutoFillPasswordsEnabled(true);
-      await sim.setAutoFillPasswordsEnabled(false);
+      await sim.setAutoFillPasswords(true);
+      await sim.setAutoFillPasswords(false);
     });
   });
 


### PR DESCRIPTION
This PR adds `setAutoFillPasswordsEnabled` function that allows to switch `AutoFill Passwords` preference.

The background is that the default AutoFill password setting has been changed since iOS16, and the behavior has been changed to suggest autofillable passwords when entering passwords. I would like to align the AutoFill Passwords settings for cross version testing. Also here is another request to disable it for another reason https://github.com/SeleniumHQ/selenium/issues/11426

Note that `setAutoFillPasswordsEnabled` enables/disables autofill settings internally but it's not reflected in the appearance of toggle switch on the settings application.
![スクリーンショット 2023-09-06 19 21 59](https://github.com/appium/appium-ios-simulator/assets/8503062/40752c9a-a811-4b22-a1c0-92045083ae84)

ref: [related discussion ](https://appium.slack.com/archives/C02956V3H/p1692779001358339)