### PR TITLE
fix: appropriately translate com.apple.SpringBoard and some system prompts

### DIFF
--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -578,6 +578,11 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       ])));
     }
 
+    // In order to translate com.apple.SpringBoard, system prompts for push notification and system prompts for location
+    await B.all(['com.apple.SpringBoard', 'com.apple.locationd'].map((arg) => this.simctl.spawnProcess([
+      'launchctl', 'stop', arg
+    ])));
+
     return true;
   }
 }


### PR DESCRIPTION
- address: https://github.com/appium/appium/issues/19181
- I confirmed the behaviour using Xcode 14.3.1 and iOS simulator 16.4.
- As far as I checked locally, we don't need anything for the following system prompts
    - Access to Your Photos
    - Access to Your Microphone
    - Access to Your Contacts
    - Request App Store Reviews
    - Enable iCloud Syncing
    - App Tracking Transparency