### PR TITLE
fix: Only restart springboard if the system language is changed

### DIFF
--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -578,10 +578,15 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       ])));
     }
 
-    // In order to translate com.apple.SpringBoard, system prompts for push notification and system prompts for location
-    await B.all(['com.apple.SpringBoard', 'com.apple.locationd'].map((arg) => this.simctl.spawnProcess([
-      'launchctl', 'stop', arg
-    ])));
+    if (globalPrefs.AppleLanguages) {
+      // In order to translate com.apple.SpringBoard, system prompts
+      // for push notification and system prompts for location
+      await B.all(['com.apple.SpringBoard', 'com.apple.locationd']
+        .map((arg) => this.simctl.spawnProcess([
+          'launchctl', 'stop', arg
+        ]))
+      );
+    }
 
     return true;
   }


### PR DESCRIPTION
I assume there is no need to restart springboard if only keyboard or locale changes are applied. 

Relates to https://github.com/appium/appium/issues/19202

cc @mwakizaka 