### PR TITLE
fix: appropriately translate some system prompts on iOS 16.1 simulator

### DIFF
--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -19,6 +19,10 @@ const startupLock = new AsyncLock();
 const preferencesPlistGuard = new AsyncLock();
 const ENROLLMENT_NOTIFICATION_RECEIVER = 'com.apple.BiometricKit.enrollmentChanged';
 const DOMAIN_KEYBOARD_PREFERENCES = 'com.apple.keyboard.preferences';
+// com.apple.SpringBoard: translates com.apple.SpringBoard and system prompts for push notification
+// com.apple.locationd: translates system prompts for location
+// com.apple.tccd: translates system prompts for camera, microphone, contact, photos and app tracking transparency
+const SERVICES_FOR_TRANSLATION = ['com.apple.SpringBoard', 'com.apple.locationd', 'com.apple.tccd'];
 
 /**
  * Creates device and common Simulator preferences, which could
@@ -579,14 +583,9 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     }
 
     if (globalPrefs.AppleLanguages) {
-      // com.apple.SpringBoard: translates com.apple.SpringBoard and system prompts for push notification
-      // com.apple.locationd: translates system prompts for location
-      // com.apple.tccd: translates system prompts for camera, microphone, contact, photos and app tracking transparency
-      await B.all(['com.apple.SpringBoard', 'com.apple.locationd', 'com.apple.tccd']
-        .map((arg) => this.simctl.spawnProcess([
-          'launchctl', 'stop', arg
-        ]))
-      );
+      await B.all(SERVICES_FOR_TRANSLATION.map((arg) => this.simctl.spawnProcess([
+        'launchctl', 'stop', arg
+      ])));
     }
 
     return true;

--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -579,9 +579,10 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     }
 
     if (globalPrefs.AppleLanguages) {
-      // In order to translate com.apple.SpringBoard, system prompts
-      // for push notification and system prompts for location
-      await B.all(['com.apple.SpringBoard', 'com.apple.locationd']
+      // com.apple.SpringBoard: translates com.apple.SpringBoard and system prompts for push notification
+      // com.apple.locationd: translates system prompts for location
+      // com.apple.tccd: translates system prompts for camera, microphone, contact, photos and app tracking transparency
+      await B.all(['com.apple.SpringBoard', 'com.apple.locationd', 'com.apple.tccd']
         .map((arg) => this.simctl.spawnProcess([
           'launchctl', 'stop', arg
         ]))


### PR DESCRIPTION
- Continued from https://github.com/appium/appium-ios-simulator/pull/384
- When using iOS 16.1 simulator on Xcode 15.0 (CoreSimulator-932.2, xcrun version 67), the following system prompts are not appropriately translated.
    1. `"<App name>" Would Like to Access the Camera`
    2. `"<App name>" Would Like to Access the Microphone`
    3. `"<App name>" Would Like to Access Your Contacts`
    4. `"<App name>" Would Like to Access Your Photos`
    5. `Allow "<App name>" to track your activity across other companies' apps and websites`

By stopping `com.apple.tccd`, I've confirmed the above system prompts are appropriately translated.