### PR TITLE
fix: Only restart system services if the language is actually changed

### DIFF
--- a/lib/simulator-xcode-9.js
+++ b/lib/simulator-xcode-9.js
@@ -23,6 +23,7 @@ const DOMAIN_KEYBOARD_PREFERENCES = 'com.apple.keyboard.preferences';
 // com.apple.locationd: translates system prompts for location
 // com.apple.tccd: translates system prompts for camera, microphone, contact, photos and app tracking transparency
 const SERVICES_FOR_TRANSLATION = ['com.apple.SpringBoard', 'com.apple.locationd', 'com.apple.tccd'];
+const GLOBAL_PREFS_PLIST = '.GlobalPreferences.plist';
 
 /**
  * Creates device and common Simulator preferences, which could
@@ -566,9 +567,20 @@ class SimulatorXcode9 extends SimulatorXcode8 {
       return false;
     }
 
+    let previousAppleLanguages = null;
+    if (globalPrefs.AppleLanguages) {
+      const absolutePrefsPath = path.join(this.getDir(), 'Library', 'Preferences', GLOBAL_PREFS_PLIST);
+      try {
+        const {stdout} = await exec('plutil', ['-convert', 'json', absolutePrefsPath, '-o', '-']);
+        previousAppleLanguages = JSON.parse(stdout).AppleLanguages;
+      } catch (e) {
+        log.debug(`Cannot retrieve the current value of the 'AppleLanguages' preference: ${e.message}`);
+      }
+    }
+
     const argChunks = generateDefaultsCommandArgs(globalPrefs, true);
     await B.all(argChunks.map((args) => this.simctl.spawnProcess([
-      'defaults', 'write', '.GlobalPreferences.plist', ...args
+      'defaults', 'write', GLOBAL_PREFS_PLIST, ...args
     ])));
 
     if (keyboard && keyboardId) {
@@ -583,9 +595,21 @@ class SimulatorXcode9 extends SimulatorXcode8 {
     }
 
     if (globalPrefs.AppleLanguages) {
-      await B.all(SERVICES_FOR_TRANSLATION.map((arg) => this.simctl.spawnProcess([
-        'launchctl', 'stop', arg
-      ])));
+      if (previousAppleLanguages && previousAppleLanguages === globalPrefs.AppleLanguages) {
+        log.info(
+          `The 'AppleLanguages' preference is already set to '${globalPrefs.AppleLanguages}'. ` +
+          `Skipping services reset`
+        );
+      } else {
+        log.info(
+          `Will restart the following services in order to sync UI dialogs translation: ` +
+          `${SERVICES_FOR_TRANSLATION}. This might have unexpected side effects, ` +
+          `see https://github.com/appium/appium/issues/19440 for more details`
+        );
+        await B.all(SERVICES_FOR_TRANSLATION.map((arg) => this.simctl.spawnProcess([
+          'launchctl', 'stop', arg
+        ])));
+      }
     }
 
     return true;

--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
     "semantic-release": "^22.0.5",
     "sinon": "^17.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "~5.2"
   }
 }


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/19440

Perhaps, we need to add a separate capability to xcuitest driver as the next step to control this behaviour, so users could choose what is more important for them: running/cached WDA or fully translated UI dialogs.

cc @mwakizaka 