### PR TITLE
fix: system prompt for Apple ID sign in unexpectedly not translated

### DIFF
--- a/lib/extensions/settings.js
+++ b/lib/extensions/settings.js
@@ -10,7 +10,8 @@ import { fs } from '@appium/support';
 // com.apple.SpringBoard: translates com.apple.SpringBoard and system prompts for push notification
 // com.apple.locationd: translates system prompts for location
 // com.apple.tccd: translates system prompts for camera, microphone, contact, photos and app tracking transparency
-const SERVICES_FOR_TRANSLATION = ['com.apple.SpringBoard', 'com.apple.locationd', 'com.apple.tccd'];
+// com.apple.akd: translates `Sign in with your Apple ID` system prompt
+const SERVICES_FOR_TRANSLATION = ['com.apple.SpringBoard', 'com.apple.locationd', 'com.apple.tccd', 'com.apple.akd'];
 const GLOBAL_PREFS_PLIST = '.GlobalPreferences.plist';
 const PREFERENCES_PLIST_GUARD = new AsyncLock();
 const DOMAIN = /** @type {const} */ Object.freeze({

--- a/test/unit/simulator-specs.js
+++ b/test/unit/simulator-specs.js
@@ -209,7 +209,10 @@ launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/
         spawnProcessSpy.getCall(3).args[0].should.eql(
           ['launchctl', 'stop', 'com.apple.tccd']
         );
-        spawnProcessSpy.callCount.should.eql(4);
+        spawnProcessSpy.getCall(4).args[0].should.eql(
+          ['launchctl', 'stop', 'com.apple.akd']
+        );
+        spawnProcessSpy.callCount.should.eql(5);
       });
 
       it('should confirm skip restarting services if already applied', async function () {


### PR DESCRIPTION
Hi, 

I happened to find that we need to stop `com.apple.akd` as well for appropriately translating `Sign in with your Apple ID` system prompt.

- Before
<img width="385" alt="Screenshot 2024-06-05 at 15 22 34" src="https://github.com/appium/appium-ios-simulator/assets/21286384/b4352150-6537-45e9-9f86-559f4f3f66c5">

- After
<img width="387" alt="Screenshot 2024-06-05 at 15 23 09" src="https://github.com/appium/appium-ios-simulator/assets/21286384/2ff8b000-2c3f-48ee-acc3-6f91a0345251">
