### PR TITLE
fix: type error by xmldom

### DIFF
--- a/lib/defaults-utils.js
+++ b/lib/defaults-utils.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { DOMParser, Element, XMLSerializer } from '@xmldom/xmldom';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import { exec } from 'teen_process';
 import B from 'bluebird';
 import log from './logger';
@@ -12,7 +12,7 @@ import log from './logger';
  * @param {any} value The value to be serialized
  * @param {boolean} serialize [true] Whether to serialize the resulting
  * XML to string or to return raw HTMLElement instance
- * @returns {Element|string} Either string or raw node representation of
+ * @returns {xmlDomElement|string} Either string or raw node representation of
  * the given value
  * @throws {TypeError} If it is not known how to serialize the given value
  */
@@ -25,17 +25,17 @@ export function toXmlArg (value, serialize = true) {
       const keyEl = xmlDoc.createElement('key');
       const keyTextEl = xmlDoc.createTextNode(subKey);
       keyEl.appendChild(keyTextEl);
-      xmlDoc.documentElement?.appendChild(keyEl);
+      /** @type{xmlDomElement} */ (xmlDoc.documentElement).appendChild(keyEl);
       // @ts-ignore The typecast here is fine
       const subValueEl = xmlDoc.importNode(toXmlArg(subValue, false), true);
-      xmlDoc.documentElement?.appendChild(subValueEl);
+      /** @type{xmlDomElement} */ (xmlDoc.documentElement).appendChild(subValueEl);
     }
   } else if (_.isArray(value)) {
     xmlDoc = new DOMParser().parseFromString('<array></array>', 'text/xml');
     for (const subValue of value) {
       // @ts-ignore The typecast here is fine
       const subValueEl = xmlDoc.importNode(toXmlArg(subValue, false), true);
-      xmlDoc.documentElement?.appendChild(subValueEl);
+      /** @type{xmlDomElement} */ (xmlDoc.documentElement).appendChild(subValueEl);
     }
   } else if (_.isBoolean(value)) {
     xmlDoc = new DOMParser().parseFromString(value ? '<true/>' : '<false/>', 'text/xml');
@@ -46,17 +46,17 @@ export function toXmlArg (value, serialize = true) {
   } else if (_.isString(value)) {
     xmlDoc = new DOMParser().parseFromString(`<string></string>`, 'text/xml');
     const valueTextEl = xmlDoc.createTextNode(value);
-    xmlDoc.documentElement?.appendChild(valueTextEl);
+    /** @type{xmlDomElement} */ (xmlDoc.documentElement).appendChild(valueTextEl);
   }
 
-  if (!xmlDoc || !xmlDoc.documentElement) {
+  if (!xmlDoc) {
     throw new TypeError(`The defaults value ${JSON.stringify(value)} cannot be written, ` +
       `because it is not known how to handle its type`);
   }
 
-  return serialize && xmlDoc.documentElement
-    ? new XMLSerializer().serializeToString(xmlDoc.documentElement)
-    : xmlDoc.documentElement;
+  return serialize
+    ? new XMLSerializer().serializeToString(/** @type{xmlDomElement} */ (xmlDoc.documentElement))
+    : /** @type{xmlDomElement} */ (xmlDoc.documentElement);
 }
 
 /**
@@ -154,3 +154,7 @@ export class NSUserDefaults {
     }
   }
 }
+
+/**
+ * @typedef {import('@xmldom/xmldom').Element} xmlDomElement
+ */

--- a/lib/defaults-utils.js
+++ b/lib/defaults-utils.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { DOMParser, Element, XMLSerializer } from '@xmldom/xmldom';
 import { exec } from 'teen_process';
 import B from 'bluebird';
 import log from './logger';
@@ -12,7 +12,7 @@ import log from './logger';
  * @param {any} value The value to be serialized
  * @param {boolean} serialize [true] Whether to serialize the resulting
  * XML to string or to return raw HTMLElement instance
- * @returns {Node|string} Either string or raw node representation of
+ * @returns {Element|string} Either string or raw node representation of
  * the given value
  * @throws {TypeError} If it is not known how to serialize the given value
  */
@@ -25,17 +25,17 @@ export function toXmlArg (value, serialize = true) {
       const keyEl = xmlDoc.createElement('key');
       const keyTextEl = xmlDoc.createTextNode(subKey);
       keyEl.appendChild(keyTextEl);
-      xmlDoc.documentElement.appendChild(keyEl);
+      xmlDoc.documentElement?.appendChild(keyEl);
       // @ts-ignore The typecast here is fine
       const subValueEl = xmlDoc.importNode(toXmlArg(subValue, false), true);
-      xmlDoc.documentElement.appendChild(subValueEl);
+      xmlDoc.documentElement?.appendChild(subValueEl);
     }
   } else if (_.isArray(value)) {
     xmlDoc = new DOMParser().parseFromString('<array></array>', 'text/xml');
     for (const subValue of value) {
       // @ts-ignore The typecast here is fine
       const subValueEl = xmlDoc.importNode(toXmlArg(subValue, false), true);
-      xmlDoc.documentElement.appendChild(subValueEl);
+      xmlDoc.documentElement?.appendChild(subValueEl);
     }
   } else if (_.isBoolean(value)) {
     xmlDoc = new DOMParser().parseFromString(value ? '<true/>' : '<false/>', 'text/xml');
@@ -46,15 +46,15 @@ export function toXmlArg (value, serialize = true) {
   } else if (_.isString(value)) {
     xmlDoc = new DOMParser().parseFromString(`<string></string>`, 'text/xml');
     const valueTextEl = xmlDoc.createTextNode(value);
-    xmlDoc.documentElement.appendChild(valueTextEl);
+    xmlDoc.documentElement?.appendChild(valueTextEl);
   }
 
-  if (!xmlDoc) {
+  if (!xmlDoc || !xmlDoc.documentElement) {
     throw new TypeError(`The defaults value ${JSON.stringify(value)} cannot be written, ` +
       `because it is not known how to handle its type`);
   }
 
-  return serialize
+  return serialize && xmlDoc.documentElement
     ? new XMLSerializer().serializeToString(xmlDoc.documentElement)
     : xmlDoc.documentElement;
 }


### PR DESCRIPTION
```
lib/defaults-utils.js:15:14 - error TS2304: Cannot find name 'Node'.

15  * @returns {Node|string} Either string or raw node representation of
                ~~~~

lib/defaults-utils.js:28:7 - error TS18047: 'xmlDoc.documentElement' is possibly 'null'.

28       xmlDoc.documentElement.appendChild(keyEl);
         ~~~~~~~~~~~~~~~~~~~~~~

lib/defaults-utils.js:31:7 - error TS18047: 'xmlDoc.documentElement' is possibly 'null'.

31       xmlDoc.documentElement.appendChild(subValueEl);
         ~~~~~~~~~~~~~~~~~~~~~~

lib/defaults-utils.js:38:7 - error TS18047: 'xmlDoc.documentElement' is possibly 'null'.

38       xmlDoc.documentElement.appendChild(subValueEl);
         ~~~~~~~~~~~~~~~~~~~~~~

lib/defaults-utils.js:49:5 - error TS18047: 'xmlDoc.documentElement' is possibly 'null'.

49     xmlDoc.documentElement.appendChild(valueTextEl);
       ~~~~~~~~~~~~~~~~~~~~~~

lib/defaults-utils.js:58:45 - error TS2345: Argument of type 'Element | null' is not assignable to parameter of type 'Node'.
  Type 'null' is not assignable to type 'Node'.

58     ? new XMLSerializer().serializeToString(xmlDoc.documentElement)
                                               ~~~~~~~~~~~~~~~~~~~~~~


Found 6 errors.
```