### PR TITLE
fix: Wait for springboard restart and spotlight application restart after applesimutils invocation

### DIFF
--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -287,11 +287,15 @@ async function runAndWaitForSystemReadiness(fn, timeoutMs) {
     // Make sure the springboard process restarted first.
     const timer = new timing.Timer().start();
     await waitForNewPid(initialSpringboardPid, SPRINGBOARD_BUNDLE_ID, timeoutMs);
-    const remainingTimeout = timeoutMs - timer.getDuration().asMilliSeconds;
+    const remainingTimeoutMs = timeoutMs - timer.getDuration().asMilliSeconds;
+    if (remainingTimeoutMs <= 0) {
+      // no need to check the SPOTLIGHT_BUNDLE_ID
+      return [false, result];
+    }
 
     // Then, checking if the new spring board process refreshes applications.
     // Spotlight.app is widely used so the app process can be an indicator to check the refresh.
-    await waitForNewPid(initialSpotlightPid, SPOTLIGHT_BUNDLE_ID, remainingTimeout);
+    await waitForNewPid(initialSpotlightPid, SPOTLIGHT_BUNDLE_ID, remainingTimeoutMs);
   } catch {
     return [true, result];
   }

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -255,22 +255,22 @@ async function setAccess (bundleId, permissionsMapping) {
  * @returns {Promise<[boolean, T]>}
  */
 async function runAndWaitForSpringboardRestart(fn, timeoutMs) {
-  /** @type {() => Promise<number | undefined>} */
-  const getSpringboardPid = async () => {
+  /** @type {(string) => Promise<number | undefined>} */
+  const getPid = async (bundleId) => {
     try {
-      return (await this.ps()).find(({name}) => SPRINGBOARD_BUNDLE_ID === name)?.pid;
+      return (await this.ps()).find(({name}) => bundleId === name)?.pid;
     } catch {}
   };
 
-  /** @type {() => Promise<number | undefined>} */
-  const getSpotlightPid = async () => {
-    try {
-      return (await this.ps()).find(({name}) => SPOTLIGHT_BUNDLE_ID === name)?.pid;
-    } catch {}
+  const waitForNewPid = async (initialPid, bundleId) => {
+    await waitForCondition(async () => {
+      const pid = await getPid(bundleId);
+      return _.isInteger(pid) && initialPid !== pid;
+    }, {waitMs: timeoutMs, intervalMs: 500});
   };
 
-  const initialSpringboardPid = await getSpringboardPid();
-  const initialSpotlightPid = await getSpotlightPid();
+  const initialSpringboardPid = await getPid(SPRINGBOARD_BUNDLE_ID);
+  const initialSpotlightPid = await getPid(SPOTLIGHT_BUNDLE_ID);
   const result = await fn();
   if (!_.isInteger(initialSpringboardPid)) {
     // there is no point to wait if springboard was not running before
@@ -278,23 +278,10 @@ async function runAndWaitForSpringboardRestart(fn, timeoutMs) {
   }
 
   try {
-    await waitForCondition(async () => {
-      const springboardPid = await getSpringboardPid();
-      return _.isInteger(springboardPid) && initialSpringboardPid !== springboardPid;
-    }, {waitMs: timeoutMs, intervalMs: 500});
-
+    await waitForNewPid(initialSpringboardPid, SPRINGBOARD_BUNDLE_ID);
     // To check if the new spring board pid refresh applications.
     // Spotlight.app is widely used so the app process can be an indicator to check the refresh.
-    if (initialSpotlightPid) {
-      await waitForCondition(async () => {
-        const spotlightPid = await getSpotlightPid();
-        return _.isInteger(spotlightPid) && initialSpotlightPid !== spotlightPid;
-      }, {waitMs: timeoutMs, intervalMs: 500});
-    } else {
-      this.log.info(`The simulator might not have ${SPOTLIGHT_BUNDLE_ID} process to check ` +
-        `the application process refresh by ${SPOTLIGHT_BUNDLE_ID} restart. ` +
-        `Please report it to Appium team.`);
-    }
+    await waitForNewPid(initialSpotlightPid, SPOTLIGHT_BUNDLE_ID);
   } catch {
     return [true, result];
   }

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -15,7 +15,7 @@ const SPRINGBOARD_BUNDLE_ID = 'com.apple.SpringBoard';
 const SPOTLIGHT_BUNDLE_ID = 'com.apple.Spotlight';
 const WIX_SIM_UTILS = 'applesimutils';
 const SERVICES_NEED_SPRINGBOARD_RESTART = ['notifications'];
-const SPRINGBOARD_RESTART_TIMEOUT_MS = 15000;
+const SYSTEM_SERVICE_RESTART_TIMEOUT_MS = 15000;
 // `location` permission does not work with WIX/applesimutils.
 // Note that except for 'contacts', the Apple's privacy command sets
 // permissions properly but it kills the app process while WIX/applesimutils does not.
@@ -230,12 +230,12 @@ async function setAccess (bundleId, permissionsMapping) {
     );
     if (shouldWaitForSystemReadiness) {
       const [didTimeout] = await runAndWaitForSystemReadiness.bind(this)(
-        execWixFn, SPRINGBOARD_RESTART_TIMEOUT_MS
+        execWixFn, SYSTEM_SERVICE_RESTART_TIMEOUT_MS
       );
       if (didTimeout) {
         this.log.warn(
-          `The Springboard service did not restart after ${SPRINGBOARD_RESTART_TIMEOUT_MS}ms ` +
-          `timeout. This might lead to unexpected consequences later.`
+          `The Springboard service and apps restarted by the springboard process restart did not restart ` +
+          `after ${SYSTEM_SERVICE_RESTART_TIMEOUT_MS}ms timeout. This might lead to unexpected consequences later.`
         );
       }
     } else {
@@ -248,7 +248,7 @@ async function setAccess (bundleId, permissionsMapping) {
 
 /**
  * Waiting for springboard restart and applications process end/restart
- * kicked by the springboard process restart.
+ * triggered by the springboard process restart.
  *
  * @this {import('../types').CoreSimulator}
  * @template {any} T

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -234,8 +234,8 @@ async function setAccess (bundleId, permissionsMapping) {
       );
       if (didTimeout) {
         this.log.warn(
-          `The Springboard service and apps restarted by the springboard process restart did not restart ` +
-          `after ${SYSTEM_SERVICE_RESTART_TIMEOUT_MS}ms timeout. This might lead to unexpected consequences later.`
+          `The required system services did not restart after ` +
+          `${SYSTEM_SERVICE_RESTART_TIMEOUT_MS}ms timeout. This might lead to unexpected consequences later.`
         );
       }
     } else {

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { fs, util } from '@appium/support';
+import { fs, timing, util } from '@appium/support';
 import { exec } from 'teen_process';
 import path from 'path';
 import B from 'bluebird';
@@ -285,9 +285,9 @@ async function runAndWaitForSystemReadiness(fn, timeoutMs) {
 
   try {
     // Make sure the springboard process restarted first.
-    const startAt = new Date().getTime();
+    const timer = new timing.Timer().start();
     await waitForNewPid(initialSpringboardPid, SPRINGBOARD_BUNDLE_ID, timeoutMs);
-    const remainingTimeout = timeoutMs - (startAt - new Date().getTime());
+    const remainingTimeout = timer.getDuration().asMilliSeconds;
 
     // Then, checking if the new spring board process refreshes applications.
     // Spotlight.app is widely used so the app process can be an indicator to check the refresh.

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -225,11 +225,11 @@ async function setAccess (bundleId, permissionsMapping) {
       '--bundle', bundleId,
       '--setPermissions', permissionsArg,
     ]);
-    const shouldWaitForSpringboardRestart = !_.isEmpty(
+    const shouldWaitForSystemReadiness = !_.isEmpty(
       _.intersection(SERVICES_NEED_SPRINGBOARD_RESTART, _.keys(wixPermissions))
     );
-    if (shouldWaitForSpringboardRestart) {
-      const [didTimeout] = await runAndWaitForSpringboardRestart.bind(this)(
+    if (shouldWaitForSystemReadiness) {
+      const [didTimeout] = await runAndWaitForSystemReadiness.bind(this)(
         execWixFn, SPRINGBOARD_RESTART_TIMEOUT_MS
       );
       if (didTimeout) {
@@ -247,6 +247,8 @@ async function setAccess (bundleId, permissionsMapping) {
 }
 
 /**
+ * Waiting for springboard restart and applications process end/restart
+ * kicked by the springboard process restart.
  *
  * @this {import('../types').CoreSimulator}
  * @template {any} T
@@ -254,34 +256,42 @@ async function setAccess (bundleId, permissionsMapping) {
  * @param {number} timeoutMs
  * @returns {Promise<[boolean, T]>}
  */
-async function runAndWaitForSpringboardRestart(fn, timeoutMs) {
-  /** @type {(string) => Promise<number | undefined>} */
-  const getPid = async (bundleId) => {
-    try {
-      return (await this.ps()).find(({name}) => bundleId === name)?.pid;
-    } catch {}
-  };
-
-  const waitForNewPid = async (initialPid, bundleId) => {
+async function runAndWaitForSystemReadiness(fn, timeoutMs) {
+  const waitForNewPid = async (initialPid, bundleId, timeoutMs) => {
     await waitForCondition(async () => {
-      const pid = await getPid(bundleId);
-      return _.isInteger(pid) && initialPid !== pid;
+      try {
+        const pid = (await this.ps()).find(({name}) => bundleId === name)?.pid;
+        return _.isInteger(pid) && initialPid !== pid;
+      } catch {
+        return false;
+      }
     }, {waitMs: timeoutMs, intervalMs: 500});
   };
 
-  const initialSpringboardPid = await getPid(SPRINGBOARD_BUNDLE_ID);
-  const initialSpotlightPid = await getPid(SPOTLIGHT_BUNDLE_ID);
+  let initialProcesses = [];
+  try {
+    initialProcesses = await this.ps();
+  } catch {};
+
+  const [initialSpringboardPid, initialSpotlightPid] = [
+    SPRINGBOARD_BUNDLE_ID, SPOTLIGHT_BUNDLE_ID
+  ].map((bundleId) => initialProcesses.find(({name}) => bundleId === name)?.pid);
+
   const result = await fn();
-  if (!_.isInteger(initialSpringboardPid)) {
-    // there is no point to wait if springboard was not running before
+  if (!_.isInteger(initialSpringboardPid) || !_.isInteger(initialSpotlightPid)) {
+    // there is no point to wait if relevant processes were not running before
     return [false, result];
   }
 
   try {
-    await waitForNewPid(initialSpringboardPid, SPRINGBOARD_BUNDLE_ID);
-    // To check if the new spring board pid refresh applications.
+    // Make sure the springboard process restarted first.
+    const startAt = new Date().getTime();
+    await waitForNewPid(initialSpringboardPid, SPRINGBOARD_BUNDLE_ID, timeoutMs);
+    const remainingTimeout = timeoutMs - (startAt - new Date().getTime());
+
+    // Then, checking if the new spring board process refreshes applications.
     // Spotlight.app is widely used so the app process can be an indicator to check the refresh.
-    await waitForNewPid(initialSpotlightPid, SPOTLIGHT_BUNDLE_ID);
+    await waitForNewPid(initialSpotlightPid, SPOTLIGHT_BUNDLE_ID, remainingTimeout);
   } catch {
     return [true, result];
   }

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -290,7 +290,7 @@ async function runAndWaitForSystemReadiness(fn, timeoutMs) {
     const remainingTimeoutMs = timeoutMs - timer.getDuration().asMilliSeconds;
     if (remainingTimeoutMs <= 0) {
       // no need to check the SPOTLIGHT_BUNDLE_ID
-      return [false, result];
+      return [true, result];
     }
 
     // Then, checking if the new spring board process refreshes applications.

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -285,10 +285,16 @@ async function runAndWaitForSpringboardRestart(fn, timeoutMs) {
 
     // To check if the new spring board pid refresh applications.
     // Spotlight.app is widely used so the app process can be an indicator to check the refresh.
-    await waitForCondition(async () => {
-      const spotlightPid = await getSpotlightPid();
-      return _.isInteger(spotlightPid) && initialSpotlightPid !== spotlightPid;
-    }, {waitMs: timeoutMs, intervalMs: 500});
+    if (initialSpotlightPid) {
+      await waitForCondition(async () => {
+        const spotlightPid = await getSpotlightPid();
+        return _.isInteger(spotlightPid) && initialSpotlightPid !== spotlightPid;
+      }, {waitMs: timeoutMs, intervalMs: 500});
+    } else {
+      this.log.info(`The simulator might not have ${SPOTLIGHT_BUNDLE_ID} process to check ` +
+        `the application process refresh by ${SPOTLIGHT_BUNDLE_ID} restart. ` +
+        `Please report it to Appium team.`);
+    }
   } catch {
     return [true, result];
   }

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -235,7 +235,7 @@ async function setAccess (bundleId, permissionsMapping) {
         this.log.warn(
           `The Springboard service did not restart after ${SPRINGBOARD_RESTART_TIMEOUT_MS}ms ` +
           `timeout. This might lead to unexpected consequences later.`
-        )
+        );
       }
     } else {
       await execWixFn();
@@ -259,7 +259,7 @@ async function runAndWaitForSpringboardRestart(fn, timeoutMs) {
     try {
       return (await this.ps()).find(({name}) => SPRINGBOARD_BUNDLE_ID === name)?.pid;
     } catch {}
-  }
+  };
 
   const initialSpringboardPid = await getSpringboardPid();
   const result = await fn();
@@ -273,7 +273,7 @@ async function runAndWaitForSpringboardRestart(fn, timeoutMs) {
       const springboardPid = await getSpringboardPid();
       return _.isInteger(springboardPid) && initialSpringboardPid !== springboardPid;
     }, {waitMs: timeoutMs, intervalMs: 500});
-  } catch (e) {
+  } catch {
     return [true, result];
   }
   return [false, result];

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -3,6 +3,7 @@ import { fs, util } from '@appium/support';
 import { exec } from 'teen_process';
 import path from 'path';
 import B from 'bluebird';
+import { waitForCondition } from 'asyncbox';
 
 const STATUS = Object.freeze({
   UNSET: 'unset',
@@ -10,7 +11,10 @@ const STATUS = Object.freeze({
   YES: 'yes',
   LIMITED: 'limited',
 });
+const SPRINGBOARD_BUNDLE_ID = 'com.apple.SpringBoard';
 const WIX_SIM_UTILS = 'applesimutils';
+const SERVICES_NEED_SPRINGBOARD_RESTART = ['notifications'];
+const SPRINGBOARD_RESTART_TIMEOUT_MS = 15000;
 // `location` permission does not work with WIX/applesimutils.
 // Note that except for 'contacts', the Apple's privacy command sets
 // permissions properly but it kills the app process while WIX/applesimutils does not.
@@ -215,14 +219,64 @@ async function setAccess (bundleId, permissionsMapping) {
     const permissionsArg = _.toPairs(wixPermissions)
       .map((x) => `${x[0]}=${formatStatus(x[1])}`)
       .join(',');
-    await execWix.bind(this)([
+    const execWixFn = async () => await execWix.bind(this)([
       '--byId', this.udid,
       '--bundle', bundleId,
       '--setPermissions', permissionsArg,
     ]);
+    const shouldWaitForSpringboardRestart = !_.isEmpty(
+      _.intersection(SERVICES_NEED_SPRINGBOARD_RESTART, _.keys(wixPermissions))
+    );
+    if (shouldWaitForSpringboardRestart) {
+      const [didTimeout] = await runAndWaitForSpringboardRestart.bind(this)(
+        execWixFn, SPRINGBOARD_RESTART_TIMEOUT_MS
+      );
+      if (didTimeout) {
+        this.log.warn(
+          `The Springboard service did not restart after ${SPRINGBOARD_RESTART_TIMEOUT_MS}ms ` +
+          `timeout. This might lead to unexpected consequences later.`
+        )
+      }
+    } else {
+      await execWixFn();
+    }
   }
 
   return true;
+}
+
+/**
+ *
+ * @this {import('../types').CoreSimulator}
+ * @template {any} T
+ * @param {() => Promise<T>} fn
+ * @param {number} timeoutMs
+ * @returns {Promise<[boolean, T]>}
+ */
+async function runAndWaitForSpringboardRestart(fn, timeoutMs) {
+  /** @type {() => Promise<number | undefined>} */
+  const getSpringboardPid = async () => {
+    try {
+      return (await this.ps()).find(({name}) => SPRINGBOARD_BUNDLE_ID === name)?.pid;
+    } catch {}
+  }
+
+  const initialSpringboardPid = await getSpringboardPid();
+  const result = await fn();
+  if (!_.isInteger(initialSpringboardPid)) {
+    // there is no point to wait if springboard was not running before
+    return [false, result];
+  }
+
+  try {
+    await waitForCondition(async () => {
+      const springboardPid = await getSpringboardPid();
+      return _.isInteger(springboardPid) && initialSpringboardPid !== springboardPid;
+    }, {waitMs: timeoutMs, intervalMs: 500});
+  } catch (e) {
+    return [true, result];
+  }
+  return [false, result];
 }
 
 /**

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -12,6 +12,7 @@ const STATUS = Object.freeze({
   LIMITED: 'limited',
 });
 const SPRINGBOARD_BUNDLE_ID = 'com.apple.SpringBoard';
+const SPOTLIGHT_BUNDLE_ID = 'com.apple.Spotlight';
 const WIX_SIM_UTILS = 'applesimutils';
 const SERVICES_NEED_SPRINGBOARD_RESTART = ['notifications'];
 const SPRINGBOARD_RESTART_TIMEOUT_MS = 15000;
@@ -261,7 +262,15 @@ async function runAndWaitForSpringboardRestart(fn, timeoutMs) {
     } catch {}
   };
 
+  /** @type {() => Promise<number | undefined>} */
+  const getSpotlightPid = async () => {
+    try {
+      return (await this.ps()).find(({name}) => SPOTLIGHT_BUNDLE_ID === name)?.pid;
+    } catch {}
+  };
+
   const initialSpringboardPid = await getSpringboardPid();
+  const initialSpotlightPid = await getSpotlightPid();
   const result = await fn();
   if (!_.isInteger(initialSpringboardPid)) {
     // there is no point to wait if springboard was not running before
@@ -272,6 +281,13 @@ async function runAndWaitForSpringboardRestart(fn, timeoutMs) {
     await waitForCondition(async () => {
       const springboardPid = await getSpringboardPid();
       return _.isInteger(springboardPid) && initialSpringboardPid !== springboardPid;
+    }, {waitMs: timeoutMs, intervalMs: 500});
+
+    // To check if the new spring board pid refresh applications.
+    // Spotlight.app is widely used so the app process can be an indicator to check the refresh.
+    await waitForCondition(async () => {
+      const spotlightPid = await getSpotlightPid();
+      return _.isInteger(spotlightPid) && initialSpotlightPid !== spotlightPid;
     }, {waitMs: timeoutMs, intervalMs: 500});
   } catch {
     return [true, result];

--- a/lib/extensions/permissions.js
+++ b/lib/extensions/permissions.js
@@ -287,7 +287,7 @@ async function runAndWaitForSystemReadiness(fn, timeoutMs) {
     // Make sure the springboard process restarted first.
     const timer = new timing.Timer().start();
     await waitForNewPid(initialSpringboardPid, SPRINGBOARD_BUNDLE_ID, timeoutMs);
-    const remainingTimeout = timer.getDuration().asMilliSeconds;
+    const remainingTimeout = timeoutMs - timer.getDuration().asMilliSeconds;
 
     // Then, checking if the new spring board process refreshes applications.
     // Spotlight.app is widely used so the app process can be an indicator to check the refresh.


### PR DESCRIPTION
Closes https://github.com/appium/appium/issues/21116.
Inherits https://github.com/appium/appium-ios-simulator/pull/445.