### PR TITLE
feat!: Migrate the package to ESM

### DIFF
--- a/lib/extensions/applications.ts
+++ b/lib/extensions/applications.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import {fs, plist, util} from '@appium/support';
 import {waitForCondition} from 'asyncbox';
-import type {CoreSimulator, InteractsWithApps, LaunchAppOptions} from '../types';
+import type {CoreSimulator, InteractsWithApps, LaunchAppOptions} from '../types.js';
 
 type CoreSimulatorWithApps = CoreSimulator & InteractsWithApps;
 

--- a/lib/extensions/biometric.ts
+++ b/lib/extensions/biometric.ts
@@ -1,4 +1,4 @@
-import type {CoreSimulator, SupportsBiometric} from '../types';
+import type {CoreSimulator, SupportsBiometric} from '../types.js';
 import {util} from '@appium/support';
 
 type CoreSimulatorWithBiometric = CoreSimulator & SupportsBiometric;

--- a/lib/extensions/geolocation.ts
+++ b/lib/extensions/geolocation.ts
@@ -1,4 +1,4 @@
-import type {CoreSimulator, SupportsGeolocation} from '../types';
+import type {CoreSimulator, SupportsGeolocation} from '../types.js';
 
 type CoreSimulatorWithGeolocation = CoreSimulator & SupportsGeolocation;
 

--- a/lib/extensions/keychain.ts
+++ b/lib/extensions/keychain.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import {fs, mkdirp, tempDir, util} from '@appium/support';
 import {exec} from 'teen_process';
-import type {CoreSimulator, InteractsWithKeychain} from '../types';
+import type {CoreSimulator, InteractsWithKeychain} from '../types.js';
 
 type CoreSimulatorWithKeychain = CoreSimulator & InteractsWithKeychain;
 

--- a/lib/extensions/misc.ts
+++ b/lib/extensions/misc.ts
@@ -1,4 +1,4 @@
-import type {CoreSimulator, HasMiscFeatures, CertificateOptions} from '../types';
+import type {CoreSimulator, HasMiscFeatures, CertificateOptions} from '../types.js';
 import type {StringRecord} from '@appium/types';
 
 type CoreSimulatorWithMiscFeatures = CoreSimulator & HasMiscFeatures;

--- a/lib/extensions/permissions.ts
+++ b/lib/extensions/permissions.ts
@@ -2,7 +2,7 @@ import {fs, timing, util} from '@appium/support';
 import {exec} from 'teen_process';
 import path from 'node:path';
 import {waitForCondition} from 'asyncbox';
-import type {CoreSimulator, SupportsAppPermissions} from '../types';
+import type {CoreSimulator, SupportsAppPermissions} from '../types.js';
 import type {StringRecord} from '@appium/types';
 
 type CoreSimulatorWithAppPermissions = CoreSimulator & SupportsAppPermissions;

--- a/lib/extensions/safari.ts
+++ b/lib/extensions/safari.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import {fs, timing} from '@appium/support';
-import {MOBILE_SAFARI_BUNDLE_ID, SAFARI_STARTUP_TIMEOUT_MS} from '../utils';
+import {MOBILE_SAFARI_BUNDLE_ID, SAFARI_STARTUP_TIMEOUT_MS} from '../utils/index.js';
 import {waitForCondition} from 'asyncbox';
 import {exec} from 'teen_process';
 import type {
@@ -8,7 +8,7 @@ import type {
   InteractsWithSafariBrowser,
   InteractsWithApps,
   HasSettings,
-} from '../types';
+} from '../types.js';
 import type {StringRecord} from '@appium/types';
 
 type CoreSimulatorWithSafariBrowser = CoreSimulator &

--- a/lib/extensions/settings.ts
+++ b/lib/extensions/settings.ts
@@ -1,4 +1,4 @@
-import {NSUserDefaults, generateDefaultsCommandArgs} from '../utils';
+import {NSUserDefaults, generateDefaultsCommandArgs} from '../utils/index.js';
 import path from 'node:path';
 import {exec} from 'teen_process';
 import AsyncLock from 'async-lock';
@@ -10,7 +10,7 @@ import type {
   CommonPreferences,
   RunOptions,
   LocalizationOptions,
-} from '../types';
+} from '../types.js';
 import type {StringRecord} from '@appium/types';
 
 type CoreSimulatorWithSettings = CoreSimulator & HasSettings;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
-import {getSimulator} from './simulator';
-import {killAllSimulators, simExists} from './utils';
+import {getSimulator} from './simulator.js';
+import {killAllSimulators, simExists} from './utils/index.js';
 
 export {getSimulator, killAllSimulators, simExists};
 
-export type * from './types';
+export type * from './types.js';

--- a/lib/simulator-xcode-14.ts
+++ b/lib/simulator-xcode-14.ts
@@ -1,21 +1,25 @@
 import {fs, timing, util} from '@appium/support';
 import {waitForCondition, retryInterval} from 'asyncbox';
-import {getMacAppPidByBundleId, getUiClientAppPath, SIMULATOR_UI_CLIENT_BUNDLE_ID} from './utils';
+import {
+  getMacAppPidByBundleId,
+  getUiClientAppPath,
+  SIMULATOR_UI_CLIENT_BUNDLE_ID,
+} from './utils/index.js';
 import {getPath} from 'appium-xcode';
 import {exec} from 'teen_process';
-import {log as defaultLog} from './logger';
+import {log as defaultLog} from './logger.js';
 import EventEmitter from 'node:events';
 import AsyncLock from 'async-lock';
 import path from 'node:path';
 import {Simctl} from 'node-simctl';
-import * as appExtensions from './extensions/applications';
-import * as biometricExtensions from './extensions/biometric';
-import * as safariExtensions from './extensions/safari';
-import * as keychainExtensions from './extensions/keychain';
-import * as settingsExtensions from './extensions/settings';
-import * as permissionsExtensions from './extensions/permissions';
-import * as miscExtensions from './extensions/misc';
-import * as geolocationExtensions from './extensions/geolocation';
+import * as appExtensions from './extensions/applications.js';
+import * as biometricExtensions from './extensions/biometric.js';
+import * as safariExtensions from './extensions/safari.js';
+import * as keychainExtensions from './extensions/keychain.js';
+import * as settingsExtensions from './extensions/settings.js';
+import * as permissionsExtensions from './extensions/permissions.js';
+import * as miscExtensions from './extensions/misc.js';
+import * as geolocationExtensions from './extensions/geolocation.js';
 import type {
   CoreSimulator,
   HasSettings,
@@ -31,7 +35,7 @@ import type {
   StartUiClientOptions,
   KillUiClientOptions,
   ProcessInfo,
-} from './types';
+} from './types.js';
 import type {XcodeVersion} from 'appium-xcode';
 import type {AppiumLogger, StringRecord} from '@appium/types';
 

--- a/lib/simulator-xcode-15.ts
+++ b/lib/simulator-xcode-15.ts
@@ -1,7 +1,7 @@
 import {fs} from '@appium/support';
 import path from 'node:path';
-import {readBundleIdFromPlist} from './utils';
-import {SimulatorXcode14} from './simulator-xcode-14';
+import {readBundleIdFromPlist} from './utils/index.js';
+import {SimulatorXcode14} from './simulator-xcode-14.js';
 
 export class SimulatorXcode15 extends SimulatorXcode14 {
   private _systemAppBundleIds?: Set<string>;

--- a/lib/simulator-xcode-27.ts
+++ b/lib/simulator-xcode-27.ts
@@ -1,5 +1,5 @@
-import {DEVICE_HUB_UI_CLIENT_BUNDLE_ID} from './utils';
-import {SimulatorXcode15} from './simulator-xcode-15';
+import {DEVICE_HUB_UI_CLIENT_BUNDLE_ID} from './utils/index.js';
+import {SimulatorXcode15} from './simulator-xcode-15.js';
 
 export class SimulatorXcode27 extends SimulatorXcode15 {
   /** @inheritdoc */

--- a/lib/simulator.ts
+++ b/lib/simulator.ts
@@ -1,15 +1,15 @@
-import {SimulatorXcode14} from './simulator-xcode-14';
-import {SimulatorXcode15} from './simulator-xcode-15';
-import {SimulatorXcode27} from './simulator-xcode-27';
+import {SimulatorXcode14} from './simulator-xcode-14.js';
+import {SimulatorXcode15} from './simulator-xcode-15.js';
+import {SimulatorXcode27} from './simulator-xcode-27.js';
 import {
   assertXcodeVersion,
   getSimulatorInfo,
   MIN_DEVICE_HUB_XCODE_VERSION,
   MIN_SUPPORTED_XCODE_VERSION,
-} from './utils';
+} from './utils/index.js';
 import * as xcode from 'appium-xcode';
-import {log} from './logger';
-import type {Simulator, SimulatorLookupOptions} from './types';
+import {log} from './logger.js';
+import type {Simulator, SimulatorLookupOptions} from './types.js';
 
 /**
  * Finds and returns the corresponding Simulator instance for the given ID.

--- a/lib/utils/defaults.ts
+++ b/lib/utils/defaults.ts
@@ -1,6 +1,6 @@
 import {DOMParser, XMLSerializer, type Document, type Element} from '@xmldom/xmldom';
 import {exec} from 'teen_process';
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {util} from '@appium/support';
 
 export class NSUserDefaults {

--- a/lib/utils/devices.ts
+++ b/lib/utils/devices.ts
@@ -1,5 +1,5 @@
-import type {SimulatorInfoOptions} from './types';
-import {getDevices} from './get-devices';
+import type {SimulatorInfoOptions} from './types.js';
+import {getDevices} from './get-devices.js';
 
 /**
  * @param udid - The simulator UDID.

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -5,11 +5,11 @@ export {
   DEVICE_HUB_UI_CLIENT_BUNDLE_ID,
   MIN_SUPPORTED_XCODE_VERSION,
   MIN_DEVICE_HUB_XCODE_VERSION,
-} from './constants';
-export type {SimulatorInfoOptions} from './types';
-export {NSUserDefaults, toXmlArg, generateDefaultsCommandArgs} from './defaults';
-export {getDevices} from './get-devices';
-export {getSimulatorInfo, simExists} from './devices';
-export {getMacAppPidByBundleId} from './process';
-export {assertXcodeVersion, getUiClientAppPath, readBundleIdFromPlist} from './xcode';
-export {killAllSimulators} from './lifecycle';
+} from './constants.js';
+export type {SimulatorInfoOptions} from './types.js';
+export {NSUserDefaults, toXmlArg, generateDefaultsCommandArgs} from './defaults.js';
+export {getDevices} from './get-devices.js';
+export {getSimulatorInfo, simExists} from './devices.js';
+export {getMacAppPidByBundleId} from './process.js';
+export {assertXcodeVersion, getUiClientAppPath, readBundleIdFromPlist} from './xcode.js';
+export {killAllSimulators} from './lifecycle.js';

--- a/lib/utils/lifecycle.ts
+++ b/lib/utils/lifecycle.ts
@@ -1,4 +1,4 @@
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {exec, type ExecError} from 'teen_process';
 import {waitForCondition} from 'asyncbox';
 import {getVersion} from 'appium-xcode';
@@ -6,9 +6,9 @@ import {
   DEVICE_HUB_UI_CLIENT_BUNDLE_ID,
   MIN_DEVICE_HUB_XCODE_VERSION,
   SIMULATOR_UI_CLIENT_BUNDLE_ID,
-} from './constants';
-import {getDevices} from './get-devices';
-import {getMacAppPidByBundleId, killMacAppByBundleId} from './process';
+} from './constants.js';
+import {getDevices} from './get-devices.js';
+import {getMacAppPidByBundleId, killMacAppByBundleId} from './process.js';
 
 const DEFAULT_SIM_SHUTDOWN_TIMEOUT_MS = 60000;
 

--- a/lib/utils/process.ts
+++ b/lib/utils/process.ts
@@ -1,4 +1,4 @@
-import {log} from '../logger';
+import {log} from '../logger.js';
 import {exec} from 'teen_process';
 
 /**

--- a/lib/utils/xcode.ts
+++ b/lib/utils/xcode.ts
@@ -2,7 +2,7 @@ import {fs} from '@appium/support';
 import {exec} from 'teen_process';
 import path from 'node:path';
 import {getPath, type XcodeVersion} from 'appium-xcode';
-import {MIN_DEVICE_HUB_XCODE_VERSION, MIN_SUPPORTED_XCODE_VERSION} from './constants';
+import {MIN_DEVICE_HUB_XCODE_VERSION, MIN_SUPPORTED_XCODE_VERSION} from './constants.js';
 
 /**
  * @param bundleId - The bundle identifier of the Simulator UI client.

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "format": "prettier -w ./lib ./test",
     "format:check": "prettier --check ./lib ./test",
     "prepare": "npm run build",
-    "test": "node --test --test-force-exit --test-timeout=60000 \"./build/test/unit/**/*.spec.js\"",
-    "e2e-test": "node --test --test-force-exit --test-concurrency=1 --test-timeout=3600000 \"./build/test/functional/**/*.spec.js\""
+    "test": "node --enable-source-maps --test --test-force-exit --test-timeout=60000 \"./build/test/unit/**/*.spec.js\"",
+    "e2e-test": "node --enable-source-maps --test --test-force-exit --test-concurrency=1 --test-timeout=3600000 \"./build/test/functional/**/*.spec.js\""
   },
   "prettier": {
     "bracketSpacing": false,
@@ -73,11 +73,20 @@
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.2",
     "conventional-changelog-conventionalcommits": "^9.3.1",
+    "esmock": "^2.7.6",
     "pem": "^1.8.3",
     "prettier": "^3.0.0",
     "semantic-release": "^25.0.2",
     "sinon": "^22.0.0",
     "typescript": "^6.0.2"
   },
-  "types": "./build/lib/index.d.ts"
+  "types": "./build/lib/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  }
 }

--- a/test/functional/simulator-e2e.spec.ts
+++ b/test/functional/simulator-e2e.spec.ts
@@ -1,12 +1,12 @@
-import {killAllSimulators, MOBILE_SAFARI_BUNDLE_ID} from '../../lib/utils';
-import {getSimulator} from '../../lib/simulator';
-import type {Simulator} from '../../lib/types';
+import {killAllSimulators, MOBILE_SAFARI_BUNDLE_ID} from '../../lib/utils/index.js';
+import {getSimulator} from '../../lib/simulator.js';
+import type {Simulator} from '../../lib/types.js';
 import {Simctl} from 'node-simctl';
 import {retryInterval, waitForCondition} from 'asyncbox';
-import {LONG_TIMEOUT, verifyStates} from './helpers';
+import {LONG_TIMEOUT, verifyStates} from './helpers.js';
 import {use as chaiUse, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import {getUIKitCatalogPath, UICATALOG_BUNDLE_ID} from '../setup';
+import {getUIKitCatalogPath, UICATALOG_BUNDLE_ID} from '../setup.js';
 import {describe, it, before, afterEach, beforeEach, after, type TestContext} from 'node:test';
 
 chaiUse(chaiAsPromised);

--- a/test/functional/utils-e2e.spec.ts
+++ b/test/functional/utils-e2e.spec.ts
@@ -1,8 +1,8 @@
-import {killAllSimulators} from '../../lib/utils';
-import {getSimulator} from '../../lib/simulator';
-import type {Simulator} from '../../lib/types';
+import {killAllSimulators} from '../../lib/utils/index.js';
+import {getSimulator} from '../../lib/simulator.js';
+import type {Simulator} from '../../lib/types.js';
 import {Simctl} from 'node-simctl';
-import {LONG_TIMEOUT, verifyStates} from './helpers';
+import {LONG_TIMEOUT, verifyStates} from './helpers.js';
 import {use as chaiUse} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {describe, it, beforeEach, afterEach} from 'node:test';

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,10 +1,11 @@
 import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {fs, net, tempDir, zip, node} from '@appium/support';
 
 const UICATALOG_URL =
   'https://github.com/appium/ios-uicatalog/releases/download/v4.0.1/UIKitCatalog-iphonesimulator.zip';
 const UICATALOG_CACHE_PATH = path.resolve(
-  node.getModuleRootSync('appium-ios-simulator', __filename)!,
+  node.getModuleRootSync('appium-ios-simulator', fileURLToPath(import.meta.url))!,
   'test',
   'fixtures',
   'UIKitCatalog-iphonesimulator.app',

--- a/test/unit/defaults-utils.spec.ts
+++ b/test/unit/defaults-utils.spec.ts
@@ -1,4 +1,4 @@
-import {toXmlArg, generateDefaultsCommandArgs} from '../../lib/utils';
+import {toXmlArg, generateDefaultsCommandArgs} from '../../lib/utils/index.js';
 import {expect} from 'chai';
 import {describe, it} from 'node:test';
 

--- a/test/unit/simulator.spec.ts
+++ b/test/unit/simulator.spec.ts
@@ -1,20 +1,44 @@
-import {getSimulator} from '../../lib/simulator';
-import * as teenProcess from 'teen_process';
-import * as getDevicesModule from '../../lib/utils/get-devices';
-import * as xcodeUtils from '../../lib/utils/xcode';
+import esmock from 'esmock';
 import sinon from 'sinon';
-import {devices} from './device-list';
-import {SimulatorXcode14} from '../../lib/simulator-xcode-14';
-import {SimulatorXcode15} from '../../lib/simulator-xcode-15';
-import {SimulatorXcode27} from '../../lib/simulator-xcode-27';
+import {devices} from './device-list.js';
+import {SimulatorXcode14} from '../../lib/simulator-xcode-14.js';
+import {SimulatorXcode15} from '../../lib/simulator-xcode-15.js';
+import {SimulatorXcode27} from '../../lib/simulator-xcode-27.js';
 import {use as chaiUse, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import * as xcodeModule from 'appium-xcode';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
 chaiUse(chaiAsPromised);
 
 const UDID = devices['10.0'][0].udid;
+
+let currentExec: (...args: any[]) => any = async () => ({stdout: '', stderr: ''});
+let currentGetVersion: (...args: any[]) => any = async () => ({
+  major: 14,
+  versionString: '14.0.0',
+});
+let currentAssertXcodeVersion: (...args: any[]) => any = (v: any) => v;
+let currentGetDevices: (...args: any[]) => any = async () => devices;
+
+const {getSimulator} = await esmock(
+  '../../lib/simulator.js',
+  import.meta.url,
+  {},
+  {
+    teen_process: {
+      exec: (...args: any[]) => currentExec(...args),
+    },
+    'appium-xcode': {
+      getVersion: (...args: any[]) => currentGetVersion(...args),
+    },
+    '../../lib/utils/xcode.js': {
+      assertXcodeVersion: (...args: any[]) => currentAssertXcodeVersion(...args),
+    },
+    '../../lib/utils/get-devices.js': {
+      getDevices: (...args: any[]) => currentGetDevices(...args),
+    },
+  },
+);
 
 describe('simulator', function () {
   let sandbox: sinon.SinonSandbox;
@@ -25,11 +49,13 @@ describe('simulator', function () {
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
-    assertXcodeVersionStub = sandbox.stub(xcodeUtils, 'assertXcodeVersion');
-    getDevicesStub = sandbox.stub(getDevicesModule, 'getDevices');
-    getDevicesStub.resolves(devices);
-    getVersionStub = sandbox.stub(xcodeModule, 'getVersion');
+    assertXcodeVersionStub = sandbox.stub();
+    currentAssertXcodeVersion = assertXcodeVersionStub;
+    getDevicesStub = sandbox.stub().resolves(devices);
+    currentGetDevices = getDevicesStub;
+    getVersionStub = sandbox.stub();
     getVersionStub.withArgs(true).returns(Promise.resolve({major: 14, versionString: '14.0.0'}));
+    currentGetVersion = getVersionStub;
   });
   afterEach(function () {
     sandbox.verify();
@@ -136,7 +162,7 @@ launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/
 
     beforeEach(function () {
       innerExecStub = sandbox.stub().callsFake(() => ({stdout}) as any);
-      sandbox.stub(teenProcess, 'exec').get(() => innerExecStub);
+      currentExec = innerExecStub;
       const xcodeVersion = {major: 14, versionString: '14.0.0'};
       assertXcodeVersionStub.callsFake(() => xcodeVersion);
     });
@@ -239,9 +265,7 @@ launchd_s 35621 mwakizaka   16u  unix 0x7b7dbedd6d62e84f      0t0      /private/
     describe('language', function () {
       const stdout = JSON.stringify({AppleLanguages: ['en']});
       beforeEach(function () {
-        sandbox
-          .stub(teenProcess, 'exec')
-          .get(() => sandbox.stub().callsFake(() => ({stdout}) as any));
+        currentExec = sandbox.stub().callsFake(() => ({stdout}) as any);
         sandbox.stub(sim, 'getDir').callsFake(() => '');
       });
 

--- a/test/unit/simulator.spec.ts
+++ b/test/unit/simulator.spec.ts
@@ -49,6 +49,7 @@ describe('simulator', function () {
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
+    currentExec = sandbox.stub().resolves({stdout: '', stderr: ''});
     assertXcodeVersionStub = sandbox.stub();
     currentAssertXcodeVersion = assertXcodeVersionStub;
     getDevicesStub = sandbox.stub().resolves(devices);

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,21 +1,17 @@
 import sinon from 'sinon';
-import * as TeenProcess from 'teen_process';
-import xcode from 'appium-xcode';
-import * as xcodeModule from 'appium-xcode';
+import esmock from 'esmock';
 import {
   DEVICE_HUB_UI_CLIENT_BUNDLE_ID,
   SIMULATOR_UI_CLIENT_BUNDLE_ID,
-} from '../../lib/utils/constants';
-import {killAllSimulators, simExists} from '../../lib/utils';
-import {toBiometricDomainComponent} from '../../lib/extensions/biometric';
-import {verifyDevicePreferences} from '../../lib/extensions/settings';
+} from '../../lib/utils/constants.js';
+import {toBiometricDomainComponent} from '../../lib/extensions/biometric.js';
+import {verifyDevicePreferences} from '../../lib/extensions/settings.js';
 import {use as chaiUse, expect} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import * as getDevicesModule from '../../lib/utils/get-devices';
 
 import {describe, it, beforeEach, afterEach} from 'node:test';
-import {devices} from './device-list';
-import {SimulatorXcode14} from '../../lib/simulator-xcode-14';
+import {devices} from './device-list.js';
+import {SimulatorXcode14} from '../../lib/simulator-xcode-14.js';
 
 chaiUse(chaiAsPromised);
 
@@ -41,6 +37,27 @@ const XCODE_VERSION_27 = {
   patch: undefined,
 };
 
+let currentExec: (...args: any[]) => any = async () => ({stdout: '', stderr: ''});
+let currentGetVersion: (...args: any[]) => any = async () => XCODE_VERSION_10;
+let currentGetDevices: (...args: any[]) => any = async () => devices;
+
+const {killAllSimulators, simExists} = await esmock(
+  '../../lib/utils/index.js',
+  import.meta.url,
+  {},
+  {
+    teen_process: {
+      exec: (...args: any[]) => currentExec(...args),
+    },
+    'appium-xcode': {
+      getVersion: (...args: any[]) => currentGetVersion(...args),
+    },
+    '../../lib/utils/get-devices.js': {
+      getDevices: (...args: any[]) => currentGetDevices(...args),
+    },
+  },
+);
+
 describe('util', function () {
   let sandbox: sinon.SinonSandbox;
 
@@ -49,10 +66,9 @@ describe('util', function () {
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
-    getDevicesStub = sandbox.stub(getDevicesModule, 'getDevices');
-    getDevicesStub.resolves(devices);
-    sandbox.stub(xcodeModule, 'getVersion');
-    sandbox.mock(xcode);
+    getDevicesStub = sandbox.stub().resolves(devices);
+    currentGetDevices = getDevicesStub;
+    currentGetVersion = sandbox.stub();
   });
   afterEach(function () {
     sandbox.verify();
@@ -61,15 +77,13 @@ describe('util', function () {
 
   describe('killAllSimulators', function () {
     it('should use the Simulator UI client bundle id', async function () {
-      sandbox
-        .stub(xcodeModule, 'getVersion')
-        .get(() => sandbox.stub().withArgs(true).returns(Promise.resolve(XCODE_VERSION_10)));
+      currentGetVersion = sandbox.stub().withArgs(true).returns(Promise.resolve(XCODE_VERSION_10));
       innerExecStub = sandbox.stub();
       innerExecStub.withArgs('xcrun').returns(undefined);
       innerExecStub
         .withArgs('lsappinfo', ['info', '-only', 'pid', SIMULATOR_UI_CLIENT_BUNDLE_ID])
         .throws({code: 1});
-      sandbox.stub(TeenProcess, 'exec').get(() => innerExecStub);
+      currentExec = innerExecStub;
       await killAllSimulators();
       sinon.assert.calledWith(innerExecStub, 'lsappinfo', [
         'info',
@@ -79,15 +93,13 @@ describe('util', function () {
       ]);
     });
     it('should use the DeviceHub UI client bundle id', async function () {
-      sandbox
-        .stub(xcodeModule, 'getVersion')
-        .get(() => sandbox.stub().withArgs(true).returns(Promise.resolve(XCODE_VERSION_27)));
+      currentGetVersion = sandbox.stub().withArgs(true).returns(Promise.resolve(XCODE_VERSION_27));
       innerExecStub = sandbox.stub();
       innerExecStub.withArgs('xcrun').returns(undefined);
       innerExecStub
         .withArgs('lsappinfo', ['info', '-only', 'pid', DEVICE_HUB_UI_CLIENT_BUNDLE_ID])
         .throws({code: 1});
-      sandbox.stub(TeenProcess, 'exec').get(() => innerExecStub);
+      currentExec = innerExecStub;
       await killAllSimulators();
       sinon.assert.calledWith(innerExecStub, 'lsappinfo', [
         'info',
@@ -97,9 +109,7 @@ describe('util', function () {
       ]);
     });
     it('should kill UI client by bundle id when shutdown fails', async function () {
-      sandbox
-        .stub(xcodeModule, 'getVersion')
-        .get(() => sandbox.stub().withArgs(true).returns(Promise.resolve(XCODE_VERSION_6)));
+      currentGetVersion = sandbox.stub().withArgs(true).returns(Promise.resolve(XCODE_VERSION_6));
       innerExecStub = sandbox.stub();
       innerExecStub.withArgs('xcrun').throws(new Error('xcrun failed'));
       innerExecStub
@@ -110,7 +120,7 @@ describe('util', function () {
         .returns(undefined);
       // getDevices is stubbed, so it won't call exec internally
       // The stub returns devices immediately, so waitForCondition will complete quickly
-      sandbox.stub(TeenProcess, 'exec').get(() => innerExecStub);
+      currentExec = innerExecStub;
       try {
         await killAllSimulators(500);
       } catch {}

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -66,6 +66,7 @@ describe('util', function () {
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
+    currentExec = sandbox.stub().resolves({stdout: '', stderr: ''});
     getDevicesStub = sandbox.stub().resolves(devices);
     currentGetDevices = getDevicesStub;
     currentGetVersion = sandbox.stub();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "outDir": "build",
     "types": ["node"],
     "checkJs": true,
-    "strict": true
+    "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
   },
   "include": [
     "lib",


### PR DESCRIPTION
## Summary

- Add "type": "module" and an exports map to package.json; keep main/types for compatibility.
- Explicitly set "module": "NodeNext" / "moduleResolution": "NodeNext" in tsconfig.json.
- Add .js extensions to all relative imports across lib/ and test/ (required by Node ESM resolution); fix directory-style imports (./utils → ./utils/index.js, etc.).
- Replace __filename usage with fileURLToPath(import.meta.url) in test/setup.ts.
- Add esmock as a dev dependency and rework test/unit/utils.spec.ts and test/unit/simulator.spec.ts, which stubbed local/CJS namespace imports (teen_process, appium-xcode, lib/utils/get-devices.ts, lib/utils/xcode.ts) via Sinon, since real ES module namespaces can't be mutated directly.
- Add --enable-source-maps to the test/e2e-test scripts.

BREAKING CHANGE: Consumers using require('appium-ios-simulator') must switch to import/dynamic import() — the package no longer ships a CommonJS entry point.